### PR TITLE
Updating Internal Links for Versioning Prep

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,11 +24,11 @@ ExpressLRS needs your radio to support crsfshot (a.k.a. Mixersync) to work prope
 
 For example: 0:50, 0:150, 0:250, 0:500, ...
 
-When that is the case your radio has crsfshot working and you're good to go. Click [here](/quick-start/tx-prep) to read more on OpenTX.
+When that is the case your radio has crsfshot working and you're good to go. Click [here](../../quick-start/tx-prep/) to read more on OpenTX.
 
 ## How can I flash/update x receiver/module?
 
-See [Getting Started](/quick-start/getting-started) page
+See [Getting Started](../../quick-start/getting-started/) page
 
 ## Will x Receiver work with y TX Module from z Manufacturer?
 
@@ -50,7 +50,7 @@ To confirm your update rate is working as intended, you can use the ExpressLRS L
   * 4x full-resolution (10-bit) channels for sticks (CH1-4)
   * Either:
     * **Standard Mode** 4x 2-position channels sent every frame (increased to 8x in 1.0), OR
-    * **HYBRID_SWITCHES_8 Mode** 8x 3-position channels, where CH5 (AUX1/ARM) is sent every frame, and the other 7 are sent round-robin (7 frames to send all channels) also changed in 1.0, see [Switch Modes](/software/switch-config)
+    * **HYBRID_SWITCHES_8 Mode** 8x 3-position channels, where CH5 (AUX1/ARM) is sent every frame, and the other 7 are sent round-robin (7 frames to send all channels) also changed in 1.0, see [Switch Modes](../../software/switch-config/)
 
 ## Is my binding phrase a secret?
 

--- a/docs/hardware/fan-mod.md
+++ b/docs/hardware/fan-mod.md
@@ -14,7 +14,7 @@ Initially this mod is brought to life by [Niklas Voigt](https://discordapp.com/u
 
 You need a **20x20mm** or **25x25mm** **fan** in **5V** version. 
 Both sizes are supported. To secure the fan into the cover you can use **2x M2 screws**, a thread is already in the print.
-U can solder the pins of the fan directly to the **5v port of the R9M** or use the [**Controllable Fan Mod**](https://github.com/ExpressLRS/ExpressLRS/wiki/R9M-Fan-Mod-Cover#controllable-fan-mod) which can control the fan out of software (fan blows only at >250mw). 
+U can solder the pins of the fan directly to the **5v port of the R9M** or use the [**Controllable Fan Mod**](../../hardware/fan-mod/#controllable-fan-mod) which can control the fan out of software (fan blows only at >250mw). 
 
 R9M Fan Mod Cover is build out of four Parts and a Sticker:
 
@@ -28,7 +28,9 @@ R9M Fan Mod Cover is build out of four Parts and a Sticker:
 * [R9M-ExpressLRS-900Mhz.pdf](https://github.com/ExpressLRS/ExpressLRS-Hardware/raw/master/STL/R9M-Fan-Mod-Case/R9M-ExpressLRS-900Mhz.pdf)
 
 or from [Thingiverse](https://www.thingiverse.com/thing:4829360)
+
 ***
+
 ## Controllable Fan Mod
 Additionally to the fan you'll need one NPN Transistor (e.g. `2N4401`) or N-Channel MOSFET (e.g. `BS170` has built-in Shotky-Diode) and a resistor (200-3k7)
 
@@ -45,7 +47,7 @@ The PB9 pad location on the R9M2019 module is a bit different. Please see the ph
 
 ## 2W Mod (⚠️Only do this if you know what you are doing!⚠️)
 
-Additionally to the [3D printed Cover](https://github.com/ExpressLRS/ExpressLRS/wiki/R9M-Fan-Mod-Cover#r9m-fan-mod-cover) & the [Controllable Fan Mod](https://github.com/ExpressLRS/ExpressLRS/wiki/R9M-Fan-Mod-Cover#controllable-fan-mod) you'll need:
+In addition to the [3D printed Cover](../../hardware/fan-mod/) & the [**Controllable Fan Mod**](../../hardware/fan-mod/#controllable-fan-mod) you'll need:
 
 * Fan + Heatsink ` "2507 25MM 25x25x13MM Hydraulic bearing Graphics card Cooling fan with heat sink 5V 12V m.2 SSD Fan with 2pin"`
 * Thermalpad 0.5mm ` "1pc 100mmx100mmx0.5mm GPU Northbridge IC LED Chipset Heatsink Cooling Conductive Silicone Thermal Pad,100x100x0.5mm w/ 3.2W/M-K"`

--- a/docs/hardware/nuclear-hardware.md
+++ b/docs/hardware/nuclear-hardware.md
@@ -11,13 +11,13 @@ The Nuclear RX is designed to be as small as possible, using the same software t
 Features: 
  
 - 20x20 stack mounting with break-off tabs for compact applications  
-- [SMD Antenna](/hardware/smd-antenna/)
-- [Wi-Fi updating](/software/updating/wifi-updating/)  
+- [SMD Antenna](../../hardware/smd-antenna/)
+- [Wi-Fi updating](../../software/updating/wifi-updating/)  
 - Up to 500Hz packet rate  
 
 <img src="https://media.discordapp.net/attachments/738450139693449258/834252910422392832/IMG_0665.JPG?width=910&height=682" width="40%">
 
-When you get your Nuclear RX, it will likely be on the latest release firmware. You'll probably have to update it to work with your TX. To update, follow the steps in the [Wi-Fi updating](/software/updating/wifi-updating) page. Alternatively, you can use [betaflight passthrough](/software/updating/betaflight-passthrough/) should work, but the boot jumper must be bridged while applying power to the RX.
+When you get your Nuclear RX, it will likely be on the latest release firmware. You'll probably have to update it to work with your TX. To update, follow the steps in the [Wi-Fi updating](../../software/updating/wifi-updating) page. Alternatively, you can use [betaflight passthrough](../../software/updating/betaflight-passthrough/) should work, but the boot jumper must be bridged while applying power to the RX.
 
 When building, use one of the `DIY_2400_RX_ESP8285_SX1280_via_X` targets. To use `via_wifi`, put your RX in binding mode, connect your computer to the RX's Wi-Fi, and hit upload.
 
@@ -53,7 +53,7 @@ Slap it together as seen below. Solder the wires to the pin header in the order 
 
 #### Upload firmware
 
-When you get your Nuclear RX, it will likely be on the latest release firmware. You'll probably have to update it to work with the RX you have. To update, follow the steps in the [Wi-Fi updating](/software/updating/wifi-updating/) page. If your transmitter module ever becomes bricked from a bad upload, connect it with a serial adapter as shown here. **MAKE SURE THE ADAPTER IS SET TO 3.3V; 5V WILL KILL THE MODULE!** Use tweezers or solder to bridge the boot jumper while you power on the module to put it in boot mode. Use the target `DIY_2400_TX_ESP32_SX1280_E28_via_UART`.  
+When you get your Nuclear RX, it will likely be on the latest release firmware. You'll probably have to update it to work with the RX you have. To update, follow the steps in the [Wi-Fi updating](../../software/updating/wifi-updating/) page. If your transmitter module ever becomes bricked from a bad upload, connect it with a serial adapter as shown here. **MAKE SURE THE ADAPTER IS SET TO 3.3V; 5V WILL KILL THE MODULE!** Use tweezers or solder to bridge the boot jumper while you power on the module to put it in boot mode. Use the target `DIY_2400_TX_ESP32_SX1280_E28_via_UART`.  
 <img src="https://github.com/SpencerGraffunder/ExpressLRS/blob/nuclear-hardware/PCB/2400MHz/TX_SX1280_Super_Slim/img/ftdi.png?raw=true?raw=true?width=910&height=682" width="40%">
 
 Note: The version of the boards with the 6-pad layout for programming has the TX and RX named backwards. The actual order of the pins is TX, RX, 3V3, GND, GND.

--- a/docs/hardware/spi-receivers.md
+++ b/docs/hardware/spi-receivers.md
@@ -16,12 +16,12 @@ There are two ways to bind the receiver, as shown below
 
 Put the receiver into bind mode using any of these procedures:
 
-- "Bind" button in the Betaflight Configurator, Receiver Page (if can't be found, [update](/hardware/spi-receivers/#updating) the Betaflight firmware).
+- "Bind" button in the Betaflight Configurator, Receiver Page (if can't be found, [update](../../hardware/spi-receivers/#updating) the Betaflight firmware).
 - using the CLI, type in `bind_rx` and press enter once.
 - press the bind button on the flight controller.
 - using the CLI, type in `set expresslrs_uid = 0`, press enter once, then save and reboot
 
-Enter [elrs.lua](/quick-start/tx-prep/#lua-script) in your handset and press the `Bind` button. The RX and TX should be now bound.
+Execute [elrs.lua](../../quick-start/tx-prep/#lua-script) in your handset and press the `Bind` button. The RX and TX should be now bound.
 
 **Please mind the order, RX first, TX second.**
 

--- a/docs/hardware/supported-hardware.md
+++ b/docs/hardware/supported-hardware.md
@@ -14,83 +14,83 @@ At the time of writing, here are the ExpressLRS-supported Transmitter Modules an
 
 ### Happymodel ES24Tx
 
-[Flashing Guide](/quick-start/tx-es24tx)
+[Flashing Guide](../../quick-start/tx-es24tx/)
 
 [Manufacturer Website](http://www.happymodel.cn/index.php/category/product/2-4g-system/elrs/)
 
 ### NamimnoRC Flash
 
-[Flashing Guide](/quick-start/tx-flash2400)
+[Flashing Guide](../../quick-start/tx-flash2400/)
 
 ### BetaFPV Nano 2.4GHz
 
-[Flashing Guide](/quick-start/tx-betafpv2400)
+[Flashing Guide](../../quick-start/tx-betafpv2400/)
 
 [Manufacturer Website](https://betafpv.com/products/elrs-nano-tx-module?variant=39416993382534)
 
 ### Ghost TX
 
-[Flashing Guide](/quick-start/tx-ghost2400)
+[Flashing Guide](../../quick-start/tx-ghost2400/)
 
 *Note: STLink first time flash, irreversible*
 
 ### Siyi FM30
 
-[Flashing Guide](/quick-start/tx-siyifm30)
+[Flashing Guide](../../quick-start/tx-siyifm30/)
 
 ## 2.4GHz Receivers
 
 ### Happymodel EP1 & EP2
 
-[Flashing Guide](/quick-start/rx-hmep2400)
+[Flashing Guide](../../quick-start/rx-hmep2400/)
 
 [Manufacturer Website](http://www.happymodel.cn/index.php/category/product/2-4g-system/elrs/)
 
 ### Happymodel PP
 
-[Flashing Guide](/quick-start/rx-hmpp2400)
+[Flashing Guide](../../quick-start/rx-hmpp2400/)
 
 [Manufacturer Website](http://www.happymodel.cn/index.php/category/product/2-4g-system/elrs/)
 
 ### NamimnoRC Flash
 
-[Flashing Guide](/quick-start/rx-flash2400)
+[Flashing Guide](../../quick-start/rx-flash2400/)
 
 ### BetaFPV Nano 2.4GHz
 
-[Flashing Guide](/quick-start/rx-betafpv2400)
+[Flashing Guide](../../quick-start/rx-betafpv2400/)
 
 [Manufacturer Website](https://betafpv.com/products/elrs-nano-receiver?variant=39416095408262)
 
 ### Ghost Atto Receivers
 
-[Flashing Guide](/quick-start/rx-ghost2400)
+[Flashing Guide](../../quick-start/rx-ghost2400/)
 
 *Note: STLink first time flash, irreversible*
 
 ### Siyi FR Mini
 
-[Flashing Guide](/quick-start/rx-siyiFRmini)
+[Flashing Guide](../../quick-start/rx-siyiFRmini/)
 
 ## 900Mhz Transmitter Modules
 
 ### Frsky R9M (inc. Lite & Lite Pro)
 
-[Flashing Guide](/quick-start/tx-r9m)
+[Flashing Guide](../../quick-start/tx-r9m/)
 
 ### Happymodel ES900TX
 
-[Flashing Guide](/quick-start/tx-es900tx)
+[Flashing Guide](../../quick-start/tx-es900tx/)
 
 [Manufacturer Website](http://www.happymodel.cn/index.php/category/product/2-4g-system/elrs/)
 
 ### NamimnoRC Voyager
 
-[Flashing Guide](/quick-start/tx-voyager900)
+[Flashing Guide](../../quick-start/tx-voyager900/)
 
 ### BetaFPV Nano 900Mhz
 
-[Flashing Guide](/quick-start/tx-betafpv900)
+[Flashing Guide](../../quick-start/tx-betafpv900/)
 
 [Manufacturer Website](https://betafpv.com/products/elrs-nano-tx-module?variant=39416993415302)
 
@@ -104,25 +104,25 @@ At the time of writing, here are the ExpressLRS-supported Transmitter Modules an
 - R9 Slim
 - R9 Slim+
 
-[Flashing Guide](/quick-start/rx-bootloader)
+[Flashing Guide](../../quick-start/rx-bootloader/)
 
 ### Jumper R9 Mini
 
-[Flashing Guide](/quick-start/rx-jumper900)
+[Flashing Guide](../../quick-start/rx-jumper900/)
 
 ### Happymodel ES900RX
 
-[Flashing Guide](/quick-start/rx-hmes900)
+[Flashing Guide](../../quick-start/rx-hmes900/)
 
 [Manufacturer Website](http://www.happymodel.cn/index.php/category/product/2-4g-system/elrs/)
 
 ### NamimnoRC Voyager
 
-[Flashing Guide](/quick-start/rx-voyager900)
+[Flashing Guide](../../quick-start/rx-voyager900/)
 
 ### BetaFPV Nano 900Mhz
 
-[Flashing Guide](/quick-start/rx-betafpv900)
+[Flashing Guide](../../quick-start/rx-betafpv900/)
 
 [Manufacturer Website](https://betafpv.com/products/elrs-nano-receiver?variant=39416095441030)
 
@@ -132,30 +132,30 @@ At the time of writing, here are the ExpressLRS-supported Transmitter Modules an
 
 [Manufacturer Website](http://www.happymodel.cn/index.php/2021/05/19/happymodel-elrs-f4-2g4-aio-5in1-flight-controller-built-in-spi-2-4ghz-elrs-rx/)
 
-*Note: SPI-based receiver. Doesn't need the ExpressLRS Configurator for updates. See this [page](/hardware/spi-receivers) for more info.*
+*Note: SPI-based receiver. Doesn't need the ExpressLRS Configurator for updates. See this [page](../hardware/spi-receivers/) for more info.*
 
 ### Happymodel CrazyF4 ELRS AIO 900Mhz
 
 [Manufacturer Website](http://www.happymodel.cn/index.php/2021/04/22/happymodel-crazyf4-elrs-aio-5in1-flight-controller-built-in-900mhz-elrs-rx/)
 
-*Note: Receiver firmware can be updated using the [ES915/868RX](/quick-start/rx-hmes900/#es915868rx-discontinued) methods.*
+*Note: Receiver firmware can be updated using the [ES915/868RX](../../quick-start/rx-hmes900/#es915868rx-discontinued/) methods.*
 
 ### BetaFPV F4 1S 12A AIO
 
 [Manufacturer Website](https://betafpv.com/products/f4-1s-12a-flight-controller?variant=39409298768006)
 
-*Note: Receiver firmware can be updated using the [Beta FPV Nano 2.4GHz](/quick-start/rx-betafpv2400) methods*
+*Note: Receiver firmware can be updated using the [Beta FPV Nano 2.4GHz](../../quick-start/rx-betafpv2400/) methods*
 
 ### SPRacing H7RF
 
 [Manufacturer Website](http://seriouslypro.com/spracingh7rf)
 
-*Note: SPI-based receiver. Doesn't need the ExpressLRS Configurator for updates. See this [page](/hardware/spi-receivers) for more info.*
+*Note: SPI-based receiver. Doesn't need the ExpressLRS Configurator for updates. See this [page](../../hardware/spi-receivers) for more info.*
 
 ## DIY TX Modules
 
-See this page [here](/hardware/diy-tx)
+See this page [here](../../hardware/diy-tx/)
 
 ## DIY Receivers
 
-See this page [here](/hardware/diy-rx)
+See this page [here](../../hardware/diy-rx/)

--- a/docs/info/glossary.md
+++ b/docs/info/glossary.md
@@ -14,10 +14,10 @@ Below you can find a list of terms you might not be sure about, as well as some 
 - `S.Port`: SmartPort, sometimes referred to as `sport`. FrSky "telemetry" protocol. The `S.Port` also gets used for updating FrSky receivers.
 - `OTA`: Update your device `Over The Air` (wifi)
 - `MCU`: Micro Controller Unit, generally denotes an embedded system controller as opposed to big iron cpu
-- `OSD`: On Screen Display, refer to [this page for instructions for setup in BF](https://github.com/AlessandroAU/ExpressLRS/wiki/OpenTX-and-Betaflight-Setup#rssi-and-link-quality)
+- `OSD`: On Screen Display, refer to [this page for instructions for setup in BF](../../quick-start/pre-1stflight/#rssi-and-link-quality)
 - `LQ`: Link Quality, percentage of expected packets received. Our preferred method of measuring the quality of the control link
 - `RSSI dBm`: Measure of power level measured in dBm. Basically, how strong the signal being received is
-- `RSSI`: Received Signal Strength Indicator, "arbitrary" scaled version of `RSSI dBm` or LQ. [Signal Health: LQI and RSSI Explained](https://github.com/ExpressLRS/ExpressLRS/wiki/Signal-Health:-LQI-and-RSSI-Explained)
+- `RSSI`: Received Signal Strength Indicator, "arbitrary" scaled version of `RSSI dBm` or LQ. [Signal Health: LQI and RSSI Explained](../../info/signal-health/)
 - `Lua`: Means "Moon" in Portuguese. As such, Lua is the correct way to write and not all uppercase.
 The ExpressLRS Lua script can be installed on a OpenTX radio, to easily alter TX parameters like Packet rate, Telemetry ratio and Output power.
 But also shows if the radio (OpenTX) is communicating correctly with the module. ( e.g. 0:50, 0:150, 0:200 and so on.)

--- a/docs/quick-start/binding.md
+++ b/docs/quick-start/binding.md
@@ -4,11 +4,11 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/quick-start.png)
 
-Binding can be done with either a hard coded unique binding phrase or in a more traditional way where you put the receiver and transmitter into bind mode, and they link up. There is no reason to use traditional binding if you're flashing both your TX and RX firmware anyway. If you used a bind phrase in your user defines, there is no need to read this article. Proceed to the [next section](/quick-start/pre-1stflight). If not, here is how to bind an ELRS TX and RX.
+Binding can be done with either a hard coded unique binding phrase or in a more traditional way where you put the receiver and transmitter into bind mode, and they link up. There is no reason to use traditional binding if you're flashing both your TX and RX firmware anyway. If you used a bind phrase in your user defines, there is no need to read this article. Proceed to the [next section](../../quick-start/pre-1stflight/). If not, here is how to bind an ELRS TX and RX.
 
 ## Unique Phrase
 
-You need to have a **unique** binding phrase in the [`user_defines.txt`](https://github.com/ExpressLRS/ExpressLRS/wiki/User-Defines#binding-phrase) file or entered in the "Custom Binding Phrase" box in the Configurator.  After flashing your TX and RX, they will bind automatically. [Is my binding phrase a secret?](https://github.com/ExpressLRS/ExpressLRS/wiki/FAQ#is-my-binding-phrase-a-secret)
+You need to have a **unique** binding phrase in the [`user_defines.txt`](../../software/user-defines/#binding-phrase) file or entered in the "Custom Binding Phrase" box in the Configurator.  After flashing your TX and RX, they will bind automatically. [Is my binding phrase a secret?](../../faq/#is-my-binding-phrase-a-secret)
 
 ```
 -DMY_BINDING_PHRASE="default ExpressLRS binding phrase"

--- a/docs/quick-start/firmware-options.md
+++ b/docs/quick-start/firmware-options.md
@@ -23,7 +23,7 @@ This is a relatively simple one - enable whatever regulatory domain you are in. 
 
 ## Binding Phrase
 
-This step is simple but **important**. Both the TX and RX NEED to have the same binding phrase or **ExpressLRS WILL NOT WORK**. Anyone using the same binding phrase as you will be able to control your model, so be unique. Set something memorable, and limit to alphanumeric phrases conforming to the Latin alphabet. Receivers flashed with firmware builds that do not have binding phrase enabled will support and require the traditional [binding method](../binding/). 📜 
+This step is simple but **important**. Both the TX and RX NEED to have the same binding phrase or **ExpressLRS WILL NOT WORK**. Anyone using the same binding phrase as you will be able to control your model, so be unique. Set something memorable, and limit to alphanumeric phrases conforming to the Latin alphabet. Receivers flashed with firmware builds that do not have binding phrase enabled will support and require the traditional [binding method](../../quick-start/binding/). 📜 
 
 ## Performance Options
 ```
@@ -48,7 +48,7 @@ This enables 500Hz mode for 2.4 GHz RXes and TXes. The drawback is that you have
 ```
 HYBRID_SWITCHES_8
 ```
-Changes how the AUX channels are sent over the air. The default option is Normal Mode with 8x 2-position low-latency switches. Enabling `HYBRID_SWITCHES_8` changes this to 1x 2-pos + 6x 7-pos + 1x 16-pos, with only the 2-position being low-latency. In Normal Mode, all switches are sent with every packet; while in Hybrid Mode, only AUX1 is sent with every packet and the rest are rotated through. Note: The switch mode MUST match between the **TX** and **RX**. A detailed explanation of the differences between the two options can be found in the <a href="/software/switch-config/">Switch Modes</a> page.
+Changes how the AUX channels are sent over the air. The default option is Normal Mode with 8x 2-position low-latency switches. Enabling `HYBRID_SWITCHES_8` changes this to 1x 2-pos + 6x 7-pos + 1x 16-pos, with only the 2-position being low-latency. In Normal Mode, all switches are sent with every packet; while in Hybrid Mode, only AUX1 is sent with every packet and the rest are rotated through. Note: The switch mode MUST match between the **TX** and **RX**. A detailed explanation of the differences between the two options can be found in the [Switch Modes](../../software/switch-config/) page.
 
 ```
 ENABLE_TELEMETRY
@@ -99,7 +99,7 @@ The RTTL Syntax is the same as used in old mobil phones for ringtones and some e
 ```
 UNLOCK_HIGHER_POWER 
 ```
-Majority of the ExpressLRS modules maxes out at 250mW. With this option, higher power levels can be unlocked on the modules that supports it. However, it is imperative that you have taken measures to provide ample cooling to the module's internals through the use of a [Fan Mod](https://github.com/AlessandroAU/ExpressLRS/wiki/R9M-Fan-Mod-Cover). This specifically applies to the R9M, which, from factory, supports a higher power level up to 1W; but because ExpressLRS runs at a much higher duty cycle, it taxes the circuity and thus produces heat much earlier. To keep it stable, cooling should be implemented. Without any cooling, you run the risk of ending up with a red paperweight.
+Majority of the ExpressLRS modules maxes out at 250mW. With this option, higher power levels can be unlocked on the modules that supports it. However, it is imperative that you have taken measures to provide ample cooling to the module's internals through the use of a [Fan Mod](../../hardware/fan-mod/). This specifically applies to the R9M, which, from factory, supports a higher power level up to 1W; but because ExpressLRS runs at a much higher duty cycle, it taxes the circuity and thus produces heat much earlier. To keep it stable, cooling should be implemented. Without any cooling, you run the risk of ending up with a red paperweight.
 
 ```
 UART_INVERTED
@@ -139,6 +139,6 @@ USE_R9MM_R9MINI_SBUS
 ```
 **This does not turn on SBUS protocol** it simply changes the pin used for communication from those two side pins (A9 and A10) to use the pin labeled "SBUS" on the RX, which is inverted. This is useful for F4 FCs which only have an inverted receiver input UART RX. 🔼. This is only one way, so you lose the telemetry downlink to your radio as well as passthrough flashing. Enabling this turns on CRSF protocol output on the S.BUS 🚌 pin on your R9MM/R9Mini. set serialrx_inverted = ON may also be needed within Betaflight 🐝 for compatibility
 
-*For a complete list of User Defines, head over to the [User Defines page](/software/user-defines.md).*
+*For a complete list of User Defines, head over to the [User Defines page](../../software/user-defines/).*
 
 **Done! It's time to flash the firmware on your transmitter**

--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -50,7 +50,7 @@ Blackbox is handy for evaluating the performance of the RF link for a flight. Se
 
 Initially ExpressLRS had very limited telemetry support but with Version `1.0.0-RC1` this changed and **full telemetry was added as optional feature**. The default setting only includes the link status message that includes the RSSI and Link quality.
 
-To receive all messages the feature telemetry has to be enabled in the [user defines](../../quick-start/user-defines/#telemetry). It's possible to flash your TX module *with telemetry support enabled* and use it with a RX *without telemetry enabled*. So you can flash certain receivers with telemetry support and others without it and use it with the same TX module.
+To receive all messages the feature telemetry has to be enabled in the [user defines](../../software/user-defines/#telemetry). It's possible to flash your TX module *with telemetry support enabled* and use it with a RX *without telemetry enabled*. So you can flash certain receivers with telemetry support and others without it and use it with the same TX module.
 
 The RX transmits a subset of telemetry it receives from the flight controller. Disabling certain messages only works if the flight controller firmware does support it. For Betaflight this is possible with the telemetry_disabled_* cli settings:
 

--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -8,7 +8,7 @@ Prior to your first ExpressLRS flight, you may want to do a few tweaks to your s
 
 ## Modes
 
-By default, ExpressLRS uses one-bit switches for the AUX channels. This means a three-position switch will only send two positions (fully off, or 1000, and fully on, or 2000) to Betaflight/iNav on the AUX channels. Set your modes appropriately if you are using one-bit switches, or enable HYBRID_SWITCHES_8 for expanded position options. For more information, read the <a href="/software/switch-config"> switch modes page </a>.
+By default, ExpressLRS uses one-bit switches for the AUX channels. This means a three-position switch will only send two positions (fully off, or 1000, and fully on, or 2000) to Betaflight/iNav on the AUX channels. Set your modes appropriately if you are using one-bit switches, or enable HYBRID_SWITCHES_8 for expanded position options. For more information, read the [switch modes page](../../software/switch-config/).
 ![Modes](../assets/images/Modes.jpg)
 
 ## RSSI and Link Quality
@@ -17,7 +17,7 @@ To get RSSI and Link Quality displayed in the OSD, set RSSI Channel to "Disabled
 
 ![OSD](../assets/images/OSD.jpg)
 
-If you wish to enable the rssi dBm warning, you'll have to change the alarm level using `set osd_rssi_dbm_alarm = -100` in CLI. A sensible value is 5-10 higher than the sensitivity shown in the ELRS.lua for the packet rate (e.g. 250Hz=-108, so -103 to -98 for the alarm). If using DJI Goggles, you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab. More information about signal metrics is found in <a href="/info/signal-health"> this article on signal health </a>.
+If you wish to enable the rssi dBm warning, you'll have to change the alarm level using `set osd_rssi_dbm_alarm = -100` in CLI. A sensible value is 5-10 higher than the sensitivity shown in the ELRS.lua for the packet rate (e.g. 250Hz=-108, so -103 to -98 for the alarm). If using DJI Goggles, you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab. More information about signal metrics is found in this great [article on signal health](../../info/signal-health/).
 
 ## Bench Test
 
@@ -50,7 +50,7 @@ Blackbox is handy for evaluating the performance of the RF link for a flight. Se
 
 Initially ExpressLRS had very limited telemetry support but with Version `1.0.0-RC1` this changed and **full telemetry was added as optional feature**. The default setting only includes the link status message that includes the RSSI and Link quality.
 
-To receive all messages the feature telemetry has to be enabled in the <a href="/quick-start/user-defines/#telemetry">user defines</a>. It's possible to flash your TX module *with telemetry support enabled* and use it with a RX *without telemetry enabled*. So you can flash certain receivers with telemetry support and others without it and use it with the same TX module.
+To receive all messages the feature telemetry has to be enabled in the [user defines](../../quick-start/user-defines/#telemetry). It's possible to flash your TX module *with telemetry support enabled* and use it with a RX *without telemetry enabled*. So you can flash certain receivers with telemetry support and others without it and use it with the same TX module.
 
 The RX transmits a subset of telemetry it receives from the flight controller. Disabling certain messages only works if the flight controller firmware does support it. For Betaflight this is possible with the telemetry_disabled_* cli settings:
 
@@ -74,7 +74,7 @@ set telemetry_disabled_mode = ON
 
 Since telemetry messages are sent with low priority it takes some time to transmit the data. The telemetry rate in the lua settings script controls how often a telemetry message should be sent. So a ratio of 1:2 means that every second message is a telemetry message, so the telemetry data is transferred very fast. A ratio 1:64 means that only one of 64 messages is a telemetry message and so the transfer happens much slower.
 
-The refresh rate also impacts the transfer speed. 50 Hz is slower compared to 200 Hz. So if you need fast a fast telemetry update rate choose high refresh rate, and a ratio that favors telemetry messages e.g. 200 Hz and 1:16 usually works good. For detailed information on telemetry bandwidth at different rates and ratios, see <a href="/info/telem-bandwidth/"> this page on telemetry bandwidth </a>.
+The refresh rate also impacts the transfer speed. 50 Hz is slower compared to 200 Hz. So if you need fast a fast telemetry update rate choose high refresh rate, and a ratio that favors telemetry messages e.g. 200 Hz and 1:16 usually works good. For detailed information on telemetry bandwidth at different rates and ratios, see [this page on telemetry bandwidth](../../info/telem-bandwidth/).
 
 To finish the telemetry setup open the telemetry page on your transmitter and select "Discover new sensors" and wait for the list to fill. You will notice that there is a * sign for each row. This star indicates that this telemetry sensor was just updated.  If you see a row that does not change, and the name of the row is in square brackets it means that this sensor was not updated for some time.
 

--- a/docs/quick-start/rx-betafpv2400.md
+++ b/docs/quick-start/rx-betafpv2400.md
@@ -8,7 +8,7 @@ template: main.html
 
 Target: `BETAFPV_2400_RX_via_BetaflightPassthrough`
 
-Make sure you have [wired](/quick-start/rx-fcprep/#betafpv-receivers) your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
+Make sure you have [wired](../../quick-start/rx-fcprep/#betafpv-receivers) your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
@@ -16,7 +16,7 @@ If the receiver needs a LiPo attached to get powered up, then Press and Hold the
 
 These procedures will not be needed in subsequent passthrough flashing. This is only needed on the first time you'd update the receiver from its factory firmware.
 
-Select the corresponding target in the ExpressLRS Configurator, set your [Firmware Options](/quick-start/firmware-options) and then click **Build and Flash**. For first time flashing/updating, it would normally take a while.
+Select the corresponding target in the ExpressLRS Configurator, set your [Firmware Options](../../quick-start/firmware-options) and then click **Build and Flash**. For first time flashing/updating, it would normally take a while.
 
 A `Success` message will be shown once the process is complete.
 
@@ -24,7 +24,7 @@ A `Success` message will be shown once the process is complete.
 
 Target: `BETAFPV_2400_RX_via_WIFI`
 
-With the receiver [wired](/quick-start/rx-fcprep/#betafpv-receivers) properly to your FC, select the correct target and set the [Firmware Options](/quick-start/firmware-options) in the ExpressLRS Configurator.
+With the receiver [wired](../../quick-start/rx-fcprep/#betafpv-receivers) properly to your FC, select the correct target and set the [Firmware Options](../../quick-start/firmware-options) in the ExpressLRS Configurator.
 
 **Build** the firmware. Once done, it should open a new window where the firmware.bin is. Do not close this window so you can easily navigate to it once it's time to upload the firmware into the receiver.
 
@@ -40,4 +40,4 @@ Target: `BETAFPV_2400_RX_via_UART`
 
 Wire the receiver into the FTDI, with TX on receiver connected to the Rx on the FTDI, and RX on receiver connected to the Tx of the FTDI. Wire 5V and GND of the FTDI to 5V and GND of the Receiver. Press the button while powering the RX on, and release - the LED should now be solid.
 
-Select the target and set your [Firmware Options](/quick-start/firmware-options) and once done, click on **Build and Flash**.
+Select the target and set your [Firmware Options](../../quick-start/firmware-options) and once done, click on **Build and Flash**.

--- a/docs/quick-start/rx-betafpv900.md
+++ b/docs/quick-start/rx-betafpv900.md
@@ -8,7 +8,7 @@ template: main.html
 
 Target: `BETAFPV_900_RX_via_BetaflightPassthrough`
 
-Make sure you have [wired](/quick-start/rx-fcprep/#betafpv-receivers) your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
+Make sure you have [wired](../..//quick-start/rx-fcprep/#betafpv-receivers) your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
@@ -16,7 +16,7 @@ If the receiver needs a LiPo attached to get powered up, then Press and Hold the
 
 These procedures will not be needed in subsequent passthrough flashing. This is only needed on the first time you'd update the receiver from its factory firmware.
 
-Select the corresponding target in the ExpressLRS Configurator, set your [Firmware Options](/quick-start/firmware-options) and then click **Build and Flash**. For first time flashing/updating, it would normally take a while. 
+Select the corresponding target in the ExpressLRS Configurator, set your [Firmware Options](../../quick-start/firmware-options) and then click **Build and Flash**. For first time flashing/updating, it would normally take a while. 
 
 A `Success` message will be shown once the process is complete.
 
@@ -24,7 +24,7 @@ A `Success` message will be shown once the process is complete.
 
 Target: `BETAFPV_900_RX_via_WIFI`
 
-With the receiver [wired](/quick-start/rx-fcprep/#betafpv-receivers) properly to your FC, select the correct target and set the [Firmware Options](/quick-start/firmware-options) in the ExpressLRS Configurator.
+With the receiver [wired](../../quick-start/rx-fcprep/#betafpv-receivers) properly to your FC, select the correct target and set the [Firmware Options](../../quick-start/firmware-options) in the ExpressLRS Configurator.
 
 **Build** the firmware. Once done, it should open a new window where the firmware.bin is. Do not close this window so you can easily navigate to it once it's time to upload the firmware into the receiver.
 
@@ -40,4 +40,4 @@ Target: `BETAFPV_900_RX_via_UART`
 
 Wire the receiver into the FTDI, with TX on receiver connected to the Rx on the FTDI, and RX on receiver connected to the Tx of the FTDI. Wire 5V and GND of the FTDI to 5V and GND of the Receiver. Press the button while powering the RX on, and release - the LED should now be solid.
 
-Select the target and set your [Firmware Options](/quick-start/firmware-options) and once done, click on **Build and Flash**.
+Select the target and set your [Firmware Options](../../quick-start/firmware-options) and once done, click on **Build and Flash**.

--- a/docs/quick-start/rx-betafpv900.md
+++ b/docs/quick-start/rx-betafpv900.md
@@ -8,7 +8,7 @@ template: main.html
 
 Target: `BETAFPV_900_RX_via_BetaflightPassthrough`
 
-Make sure you have [wired](../..//quick-start/rx-fcprep/#betafpv-receivers) your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
+Make sure you have [wired](../../quick-start/rx-fcprep/#betafpv-receivers) your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/rx-fcprep.md
+++ b/docs/quick-start/rx-fcprep.md
@@ -11,7 +11,7 @@ template: main.html
 ![FC Wiring](../assets/images/FC-Wiring.jpg" width ="100%")
 *Note: This will be the same wiring you'll use for flying and the subsequent firmware updates (via Passthrough). Forget the factory wiring guide!*
 
-After you've flashed the [bootloader](/quick-start/rx-bootloader) and wired your receiver as above, proceed to configure up your flight controller as shown [below](/quick-start/rx-fcprep/#serial-rx-setup).
+After you've flashed the [bootloader](../../quick-start/rx-bootloader) and wired your receiver as above, proceed to configure up your flight controller as shown [below](../../quick-start/rx-fcprep/#serial-rx-setup).
 
 *Note: R9 Slim requires flashing via STLink first. Passthrough should work for updates.*
 
@@ -27,7 +27,7 @@ Also of note is that the EP receivers require their Boot pads (see figure above)
 
 Flashing via Wifi doesn't need the Boot Pads bridged. Moreover, if it is bridged, the receiver will stay in bootloader mode and won't activate the wifi hotspot.
 
-Connect your FC to USB and configure your FC firmware as [below](/quick-start/rx-fcprep/#serial-rx-setup).
+Connect your FC to USB and configure your FC firmware as [below](../../quick-start/rx-fcprep/#serial-rx-setup).
 
 ### Happymodel ES900RX
 
@@ -39,7 +39,7 @@ As this is an ESP-based receiver, be aware that there are certain FCs that puts 
 
 Should you be updating via Wifi, the bridging of the boot pads is not needed. 
 
-Connect your FC to USB and configure your FC firmware as shown [below](/quick-start/rx-fcprep/#serial-rx-setup).
+Connect your FC to USB and configure your FC firmware as shown [below](../../quick-start/rx-fcprep/#serial-rx-setup).
 
 ### Happymodel ES915/868RX (Discontinued)
 
@@ -47,7 +47,7 @@ Connect your FC to USB and configure your FC firmware as shown [below](/quick-st
 
 Labels in the receiver show the pinouts. Connect Rx to a Tx pad in the FC and the Tx to an Rx pad in the FC. Of course, don't forget to connect VCC to a 5V pad, and GND to a GND pad on the FC.
 
-Connect your FC to USB and configure your FC firmware as shown [below](/quick-start/rx-fcprep/#serial-rx-setup).
+Connect your FC to USB and configure your FC firmware as shown [below](../../quick-start/rx-fcprep/#serial-rx-setup).
 
 ### NamimnoRC Voyager & Flash
 
@@ -61,7 +61,7 @@ Connect your FC to USB and configure your FC firmware as shown [below](/quick-st
 
 Labels in the receiver show the pinouts. Connect Rx to a Tx pad in the FC and the Tx to an Rx pad in the FC. Of course, don't forget to connect VCC to a 5V pad, and GND to a GND pad on the FC.
 
-Connect your FC to USB and configure your FC firmware as shown [below](/quick-start/rx-fcprep/#serial-rx-setup).
+Connect your FC to USB and configure your FC firmware as shown [below](../../quick-start/rx-fcprep/#serial-rx-setup).
 
 ### BetaFPV Receivers
 
@@ -77,7 +77,7 @@ Shown above are the pinouts and various components of the receivers. Connect Rx 
 
 Updating via WiFi is supported by these receivers.
 
-Connect your FC to USB and configure your FC firmware as shown [below](/quick-start/rx-fcprep/#serial-rx-setup).
+Connect your FC to USB and configure your FC firmware as shown [below](../../quick-start/rx-fcprep/#serial-rx-setup).
 
 ## Serial RX Setup
 

--- a/docs/quick-start/rx-flash2400.md
+++ b/docs/quick-start/rx-flash2400.md
@@ -16,9 +16,9 @@ Targets:
 - `NamimnoRC_FLASH_2400_ESP_RX_via_BetaflightPassthrough` 
 - `NamimnoRC_FLASH_2400_RX_via_BetaflightPassthrough`
 
-Once [wired properly](/quick-start/rx-fcprep/#namimnorc-voyager-flash) to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
+Once [wired properly](../../quick-start/rx-fcprep/#namimnorc-voyager-flash) to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
 
-If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options](/quick-start/firmware-options) set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
+If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options](../../quick-start/firmware-options) set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
 
 Once `Retry... ` lines appear, connect a LiPo if your receiver isn't powered by the USB (i.e. power up your receiver and FC). On subsequent flash, you can have the LiPo plugged in and receiver powered up from the start.
 
@@ -28,7 +28,7 @@ Wait for this process to finish. It's done once the "Success" prompt is shown.
 
 Target: `NamimnoRC_FLASH_2400_ESP_RX_via_WIFI`
 
-With the receiver [wired properly](/quick-start/rx-fcprep/#namimnorc-voyager-flash) to your FC, select the right target and set your [Firmware Options](/quick-start/firmware-options) in the ExpressLRS Configurator.
+With the receiver [wired properly](../../quick-start/rx-fcprep/#namimnorc-voyager-flash) to your FC, select the right target and set your [Firmware Options](../../quick-start/firmware-options) in the ExpressLRS Configurator.
 
 **Build** the firmware. Once done, it should open a new window where the `firmware.bin` is. Do not close this window so you can easily navigate to it once it's time to upload the firmware into the receiver.
 
@@ -43,11 +43,11 @@ Target: `NamimnoRC_FLASH_2400_ESP_RX_via_UART`
 
 Wire the receiver into the FTDI, with the TX on receiver connected to the Rx on the FTDI, and the RX on receiver connected to the Tx of the FTDI. Wire 5V and GND of the FTDI to 5V and GND of the Receiver. Press the button while powering the RX on, and release - the LED should now be solid.
 
-Select the target and set your [Firmware Options](/quick-start/firmware-options) and once done, click on **Build and Flash**.
+Select the target and set your [Firmware Options](../../quick-start/firmware-options) and once done, click on **Build and Flash**.
 
 ## STLink Updating (STM32 Only)
 Target: `NamimnoRC_FLASH_2400_RX_via_STLINK`
 
 The units provided to the documentation team did not have STM32 chips due to the chip shortage, however, the following should apply. Wire CLK, 3v3, GND and DIO to the recievers STLink pins.
 
-Select the target and set your [Firmware Options](/quick-start/firmware-options) and once done, click on **Build and Flash**.
+Select the target and set your [Firmware Options](../../quick-start/firmware-options) and once done, click on **Build and Flash**.

--- a/docs/quick-start/rx-ghost2400.md
+++ b/docs/quick-start/rx-ghost2400.md
@@ -14,7 +14,7 @@ Flashing the Ghost RX's is currently a **1 WAY** flash once you flash ExpressLRS
 
 1. Wire `3.3v`, `GND`, `CLK`, and `DIO` to their respective pins on the RX from the StLink.
 2. Select the `GHOST_ATTO_2400_via_STLINK` target.
-3. Set your [Firmware Options](/quick-start/firmware-options) and click on `Build and Flash`.
+3. Set your [Firmware Options](../../quick-start/firmware-options) and click on `Build and Flash`.
 4. Connect your receiver to your Flight Controller as normal (i.e. Rx to Tx, and Tx to Rx);
 
 Subsequent Firmware Updates can now be done using `via_BetaflightPassthrough` target.

--- a/docs/quick-start/rx-hmep2400.md
+++ b/docs/quick-start/rx-hmep2400.md
@@ -10,11 +10,11 @@ template: main.html
 
 Target: `HappyModel_EP_2400_RX_via_WIFI`
 
-[Wire up your receiver](/quick-start/rx-fcprep/#happymodel-ep1-ep2-pp) to a free UART on your Flight Controller. Wire TX on receiver to an RX pad on the FC, and the RX on receiver to a TX pad on the FC in the same UART. Wire 5v and Gnd as normal (5v to a 5v pad on FC and Gnd to a Gnd pad on the FC).
+[Wire up your receiver](../../quick-start/rx-fcprep/#happymodel-ep1-ep2-pp) to a free UART on your Flight Controller. Wire TX on receiver to an RX pad on the FC, and the RX on receiver to a TX pad on the FC in the same UART. Wire 5v and Gnd as normal (5v to a 5v pad on FC and Gnd to a Gnd pad on the FC).
 
 *Note: There are Flight Controllers that will pull the RX pads `LOW` which will put the ESP-based receivers into `Bootloader Mode` unintentionally. A solid LED light on these receivers even with the TX module off is a sign they are in Bootloader Mode. If this is the case, rewire the receiver to a different UART.*
 
-**Build** the firmware using the ExpressLRS Configurator using the correct Target and [options](/quick-start/firmware-options). Once done, it should open a new window where the `firmware.bin` is. Do not close this window so you can easily navigate to it once it's time to upload the firmware into the receiver.
+**Build** the firmware using the ExpressLRS Configurator using the correct Target and [options](../../quick-start/firmware-options). Once done, it should open a new window where the `firmware.bin` is. Do not close this window so you can easily navigate to it once it's time to upload the firmware into the receiver.
 
 Power your Flight Controller by either connecting a LiPo or attaching the USB cable (if receiver gets powered from USB via a 4v5 pad). Receiver's LED will blink slow at first, and after 20s or 30s (can be adjusted via ExpressLRS Configurator using `AUTO_WIFI_ON_INTERVAL`), it should blink fast indicating it's on Wifi Hotspot Mode.
 
@@ -26,15 +26,15 @@ A white page should load momentarily with the message **Update Success! Rebootin
 
 Target: `HappyModel_EP_2400_RX_via_BetaflightPassthrough`
 
-[Wire up your receiver](/quick-start/rx-fcprep/#happymodel-ep1-ep2-pp) to a free uart in your Flight Controller. Wire TX on receiver to an RX pad on the FC, and the RX on receiver to a TX pad on the FC in the same UART. Wire 5v and Gnd as normal (5v to a 5v pad on FC and Gnd to a Gnd pad on the FC).
+[Wire up your receiver](../../quick-start/rx-fcprep/#happymodel-ep1-ep2-pp) to a free uart in your Flight Controller. Wire TX on receiver to an RX pad on the FC, and the RX on receiver to a TX pad on the FC in the same UART. Wire 5v and Gnd as normal (5v to a 5v pad on FC and Gnd to a Gnd pad on the FC).
 
-You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [wiring guide](/quick-start/rx-fcprep/#happymodel-ep1-ep2-pp) shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
+You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [wiring guide](../../quick-start/rx-fcprep/#happymodel-ep1-ep2-pp) shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 
 *Note: if you haven't bridged the `Boot` pads but the receiver has solid LED light, your FC is probably pulling the current UART's RX pad `LOW` which will interfere with the normal and passthrough flashing of this receiver. Find another UART and wire your receiver there instead*
 
 Bridging the `Boot` pads is no longer needed past 1.0.0-RC6. 
 
-Power your FC with a LiPo, or if receiver is powered via USB (receiver is connected to a 4v5 pad), connect the FC to your USB port. Using the ExpressLRS Configurator, with the correct Target selected and [Firmware Options](/quick-start/firmware-options) set, click on **Build & Flash**. Wait for the process to finish and you should be greeted with the "Success" banner.
+Power your FC with a LiPo, or if receiver is powered via USB (receiver is connected to a 4v5 pad), connect the FC to your USB port. Using the ExpressLRS Configurator, with the correct Target selected and [Firmware Options](../../quick-start/firmware-options) set, click on **Build & Flash**. Wait for the process to finish and you should be greeted with the "Success" banner.
 
 Unplug USB and LiPo, and removed the solder on the bridged `Boot` pads. You no longer need it (past 1.0.0-RC6). Power your TX Module and then your FC to verify you are bound and has connection.
 
@@ -44,4 +44,4 @@ Target: `HappyModel_EP_2400_RX_via_UART`
 
 Wire the receiver into the FTDI, with TX on receiver connected to the Rx on the FTDI, and RX on receiver connected to the Tx of the FTDI. Wire 5V and GND of the FTDI to 5V and GND of the Receiver. Short the boot pad while powering the RX on, and release - the LED should now be solid.
 
-Select the target and set your [Firmware Options](/quick-start/firmware-options) and once done, click on **Build and Flash**.
+Select the target and set your [Firmware Options](../../quick-start/firmware-options) and once done, click on **Build and Flash**.

--- a/docs/quick-start/rx-hmep2400.md
+++ b/docs/quick-start/rx-hmep2400.md
@@ -28,7 +28,7 @@ Target: `HappyModel_EP_2400_RX_via_BetaflightPassthrough`
 
 [Wire up your receiver](/quick-start/rx-fcprep/#happymodel-ep1-ep2-pp) to a free uart in your Flight Controller. Wire TX on receiver to an RX pad on the FC, and the RX on receiver to a TX pad on the FC in the same UART. Wire 5v and Gnd as normal (5v to a 5v pad on FC and Gnd to a Gnd pad on the FC).
 
-You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The image above shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
+You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [wiring guide](/quick-start/rx-fcprep/#happymodel-ep1-ep2-pp) shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 
 *Note: if you haven't bridged the `Boot` pads but the receiver has solid LED light, your FC is probably pulling the current UART's RX pad `LOW` which will interfere with the normal and passthrough flashing of this receiver. Find another UART and wire your receiver there instead*
 

--- a/docs/quick-start/rx-hmes900.md
+++ b/docs/quick-start/rx-hmes900.md
@@ -12,11 +12,11 @@ Target: `HappyModel_RX_ES900RX_via_BetaflightPassthrough`
 
 ![ES900RX](../assets/images/es900rx-conn.png)
 
-With the receiver [wired properly](/quick-start/rx-fcprep/#happymodel-es900rx) to your FC, select the right target and set your [Firmware Options](/quick-start/firmware-options) in the ExpressLRS Configurator, then click on **Build and Flash**. First time Compile naturally takes a while but if you do the [prep work](/quick-start/rx-fcprep/#happymodel-es900rx) properly, you'll be greeted with the `Success` message soon enough!
+With the receiver [wired properly](../../quick-start/rx-fcprep/#happymodel-es900rx) to your FC, select the right target and set your [Firmware Options](../../quick-start/firmware-options) in the ExpressLRS Configurator, then click on **Build and Flash**. First time Compile naturally takes a while but if you do the [prep work](../../quick-start/rx-fcprep/#happymodel-es900rx) properly, you'll be greeted with the `Success` message soon enough!
 
 ### Flashing via Wifi
 
-With the receiver [wired properly](/quick-start/rx-fcprep/#happymodel-es900rx) to your FC, select the right target and set your [Firmware Options](/quick-start/firmware-options) in the ExpressLRS Configurator.
+With the receiver [wired properly](../../quick-start/rx-fcprep/#happymodel-es900rx) to your FC, select the right target and set your [Firmware Options](../../quick-start/firmware-options) in the ExpressLRS Configurator.
 
 **Build** the firmware. Once done, it should open a new window where the `firmware.bin` is. Do not close this window so you can easily navigate to it once it's time to upload the firmware into the receiver.
 
@@ -34,9 +34,9 @@ Target: `HappyModel_RX_ES915RX_via_BetaflightPassthrough`
 
 ![ES915RX](../assets/images/ES915rx.jpg)
 
-Once [wired properly](/quick-start/rx-fcprep/#happymodel-es915868rx-discontinued) to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
+Once [wired properly](../../quick-start/rx-fcprep/#happymodel-es915868rx-discontinued) to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
 
-If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options](/quick-start/firmware-options) set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
+If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options](../../quick-start/firmware-options) set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
 
 Once `Retry... ` lines appear, connect a LiPo if your receiver isn't powered by the USB (i.e. power up your receiver and FC). On subsequent flash, you can have the LiPo plugged in and receiver powered up from the start.
 
@@ -46,8 +46,8 @@ Wait for this process to finish. It's done once the "Success" prompt is shown.
 
 Target: `HappyModel_RX_ES915RX_via_STLINK`
 
-Wire up your receiver to your STLink, shown [here](/quick-start/rx-stlink/#es915rx-discontinued).
+Wire up your receiver to your STLink, shown [here](../../quick-start/rx-stlink/#es915rx-discontinued).
 
-Using the correct target specific for your receiver, set your [Firmware Options](/quick-start/firmware-options) and hit **Build & Flash** on the ExpressLRS Configurator.
+Using the correct target specific for your receiver, set your [Firmware Options](../../quick-start/firmware-options) and hit **Build & Flash** on the ExpressLRS Configurator.
 
 Once done, wire your receiver to your Flight Controller. Passthrough flashing can now be used for updating the receiver.

--- a/docs/quick-start/rx-hmpp2400.md
+++ b/docs/quick-start/rx-hmpp2400.md
@@ -10,12 +10,12 @@ Target: `HappyModel_PP_2400_RX_via_BetaflightPassthrough`
 
 The PP receivers do not have Wifi, and so, it can only be updated via Passthrough.
 
-Follow the same wiring as that of the EP receivers shown [here](/quick-start/rx-fcprep/#happymodel-ep1-ep2-pp). The PP has a silkscreened "RT5G" on one of its side indicating the order of the pads, with R = Rx, T = Tx, 5 = 5v and G = Gnd,  respectively. Connect the Rx pad to a Tx pad on the FC, and the Tx pad to an RX pad on the FC, with 5v and Gnd to their usual connections.
+Follow the same wiring as that of the EP receivers shown [here](../../quick-start/rx-fcprep/#happymodel-ep1-ep2-pp). The PP has a silkscreened "RT5G" on one of its side indicating the order of the pads, with R = Rx, T = Tx, 5 = 5v and G = Gnd,  respectively. Connect the Rx pad to a Tx pad on the FC, and the Tx pad to an RX pad on the FC, with 5v and Gnd to their usual connections.
 
 The PP **doesn't** have a `Boot` pad either so there's no need to bridge any pads.
 
 Once wired, power up your FC by connecting a LiPo or, if the receiver is getting powered via USB, connect your USB cable to a vacant port.
 
-Using the ExpressLRS Configurator, with the correct Target selected and [Firmware Options](/quick-start/firmware-options) set, hit **Build & Flash**. Wait a bit for the process to finish and you should see a "Success" banner. 
+Using the ExpressLRS Configurator, with the correct Target selected and [Firmware Options](../../quick-start/firmware-options) set, hit **Build & Flash**. Wait a bit for the process to finish and you should see a "Success" banner. 
 
 Power-cycle the FC and verify receiver connects to the Tx module (power up the Tx first, then the Receiver).

--- a/docs/quick-start/rx-jumper900.md
+++ b/docs/quick-start/rx-jumper900.md
@@ -9,9 +9,9 @@ Targets:
 - `Jumper_RX_R900MINI_via_STLINK`
 - `Jumper_RX_R900MINI_via_BetaflightPassthrough`
 
-Disable 'Readout Protection'. To do this download the [ST-LINK Utility](https://www.st.com/en/development-tools/stsw-link004.html) and follow this quick [how to video](https://youtu.be/SEYQ1HpRmk0). Or alternatively under linux you can use <a href="/software/open-ocd">OpenOCD</a>.
+Disable 'Readout Protection'. To do this download the [ST-LINK Utility](https://www.st.com/en/development-tools/stsw-link004.html) and follow this quick [how to video](https://youtu.be/SEYQ1HpRmk0). Or alternatively under linux you can use [OpenOCD](../../software/open-ocd/).
 
-Using the correct target specific for your receiver, and your [Firmware Options](/quick-start/firmware-options) set, click **Build & Flash** on the ExpressLRS Configurator.
+Using the correct target specific for your receiver, and your [Firmware Options](../../quick-start/firmware-options/) set, click **Build & Flash** on the ExpressLRS Configurator.
 
 <img src="https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/r900mini-rx/r900mini-side2-closeup.jpg" width = "60%" alt = "R900 wiring diagram">
 

--- a/docs/quick-start/rx-r9receivers.md
+++ b/docs/quick-start/rx-r9receivers.md
@@ -18,11 +18,11 @@ Valid Targets:
 - `Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough`
 - `Frsky_RX_R9SLIMPLUS_OTA_via_BetaflightPassthrough`
 
-Make sure the correct [Bootloader](/quick-start/rx-bootloader/) has been flashed to the receiver prior to wiring it up to your flight controller. Using the wiring guide above, find a free, uninverted UART in your FC. You can use your FC's wiring guide for a Crossfire or Ghost receiver.
+Make sure the correct [Bootloader](../../quick-start/rx-bootloader/) has been flashed to the receiver prior to wiring it up to your flight controller. Using the wiring guide above, find a free, uninverted UART in your FC. You can use your FC's wiring guide for a Crossfire or Ghost receiver.
 
 Once wired to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
 
-If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options](/quick-start/firmware-options) set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
+If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options](../../quick-start/firmware-options) set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
 
 Once `Retry... ` lines appear, connect a LiPo if your receiver isn't powered by the USB (i.e. power up your FC and receiver). On subsequent flash, you can have the LiPo plugged in and receiver powered up from the start prior to connecting the USB.
 
@@ -40,10 +40,10 @@ Valid Targets:
 
 This method is irreversible. It will remove the ability to reflash back to Frsky firmware. You have been warned! Make sure your STLink dongle is properly recognized by your System as such (Drivers are installed, etc.).
 
-Disable 'Readout Protection'. To do this download the [ST-LINK Utility](https://www.st.com/en/development-tools/stsw-link004.html) and follow this quick [how to video](https://youtu.be/SEYQ1HpRmk0). Or alternatively under linux you can use <a href="/software/open-ocd">OpenOCD</a>. 
+Disable 'Readout Protection'. To do this download the [ST-LINK Utility](https://www.st.com/en/development-tools/stsw-link004.html) and follow this quick [how to video](https://youtu.be/SEYQ1HpRmk0). Or alternatively under linux you can use [OpenOCD](../../software/open-ocd/). 
 
 After doing so, Disconnect from STLink Utility.
 
-Using the correct target specific for your receiver, set your [Firmware Options](/quick-start/firmware-options) and hit **Build & Flash** on the ExpressLRS Configurator.
+Using the correct target specific for your receiver, set your [Firmware Options](../../quick-start/firmware-options) and hit **Build & Flash** on the ExpressLRS Configurator.
 
 Once done, wire your receiver to your Flight Controller. Passthrough flashing can now be used for updating the receiver.

--- a/docs/quick-start/rx-siyiFRmini.md
+++ b/docs/quick-start/rx-siyiFRmini.md
@@ -15,7 +15,7 @@ Solder 5  (preferable Silicon) wires to the GND-RST-VDD-CLK-DIO pads. Solder the
 ![pinout](https://github.com/ExpressLRS/ExpressLRS-Hardware/blob/master/img/siyi/jupa/Siyi-12.JPG?raw=true)
 ![stlink](https://github.com/ExpressLRS/ExpressLRS-Hardware/blob/master/img/siyi/jupa/Siyi-13.JPG?raw=true)
 
-Using the correct target specific for your receiver, set your [Firmware Options](/quick-start/firmware-options) and hit **Build & Flash** on the ExpressLRS Configurator.
+Using the correct target specific for your receiver, set your [Firmware Options](../../quick-start/firmware-options) and hit **Build & Flash** on the ExpressLRS Configurator.
 
 Once done, wire your receiver to your Flight Controller. Passthrough flashing can now be used for updating the receiver. The wiring is show below, where the FC TX goes to RX2 and the FC RX goes to TX2.
 

--- a/docs/quick-start/rx-voyager900.md
+++ b/docs/quick-start/rx-voyager900.md
@@ -16,9 +16,9 @@ Targets:
 - `NamimnoRC_VOYAGER_900_ESP_RX_via_BetaflightPassthrough` 
 - `NamimnoRC_VOYAGER_900_RX_via_BetaflightPassthrough`
 
-Once [wired properly](/quick-start/rx-fcprep/#namimnorc-voyager-flash) to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
+Once [wired properly](../../quick-start/rx-fcprep/#namimnorc-voyager-flash) to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
 
-If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options](/quick-start/firmware-options) set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
+If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options](../../quick-start/firmware-options) set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
 
 Once `Retry... ` lines appear, connect a LiPo if your receiver isn't powered by the USB (i.e. power up your receiver and FC). On subsequent flash, you can have the LiPo plugged in and receiver powered up from the start.
 
@@ -28,7 +28,7 @@ Wait for this process to finish. It's done once the "Success" prompt is shown.
 
 Target: `NamimnoRC_VOYAGER_900_ESP_RX_via_WIFI`
 
-With the receiver [wired properly](/quick-start/rx-fcprep/#namimnorc-voyager-flash) to your FC, select the right target and set your [Firmware Options](/quick-start/firmware-options) in the ExpressLRS Configurator.
+With the receiver [wired properly](../../quick-start/rx-fcprep/#namimnorc-voyager-flash) to your FC, select the right target and set your [Firmware Options](../../quick-start/firmware-options) in the ExpressLRS Configurator.
 
 **Build** the firmware. Once done, it should open a new window where the `firmware.bin` is. Do not close this window so you can easily navigate to it once it's time to upload the firmware into the receiver.
 
@@ -43,11 +43,11 @@ Target: `NamimnoRC_VOYAGER_900_ESP_RX_via_UART`
 
 Wire the receiver into the FTDI, with the TX on receiver connected to the Rx on the FTDI, and the RX on receiver connected to the Tx of the FTDI. Wire 5V and GND of the FTDI to 5V and GND of the Receiver. Press the button while powering the RX on, and release - the LED should now be solid.
 
-Select the target and set your [Firmware Options](/quick-start/firmware-options) and once done, click on **Build and Flash**.
+Select the target and set your [Firmware Options](../../quick-start/firmware-options) and once done, click on **Build and Flash**.
 
 ## STLink Updating (STM32 Only)
 Target: `NamimnoRC_VOYAGER_900_RX_via_STLINK`
 
 The units provided to the documentation team did not have STM32 chips due to the chip shortage, however, the following should apply. Wire CLK, 3v3, GND and DIO to the recievers STLink pins.
 
-Select the target and set your [Firmware Options](/quick-start/firmware-options) and once done, click on **Build and Flash**.
+Select the target and set your [Firmware Options](../../quick-start/firmware-options) and once done, click on **Build and Flash**.

--- a/docs/quick-start/troubleshooting.md
+++ b/docs/quick-start/troubleshooting.md
@@ -8,7 +8,7 @@ template: main.html
 
 ### My RX and TX are bound, but Betaflight is not responding to inputs
 
-You most likely updated your receiver via WiFi, but you have wired your receiver wrong or that you have an incorrect receiver configuration. You might want to revisit the [FC Preparation](/quick-start/rx-fcprep/) page for the Flight Controller setup.
+You most likely updated your receiver via WiFi, but you have wired your receiver wrong or that you have an incorrect receiver configuration. You might want to revisit the [FC Preparation](../../quick-start/rx-fcprep/) page for the Flight Controller setup.
 
 Also make sure that the UART where you connected the receiver to doesn't have inversion and it's in full duplex mode. You can also try a different UART.
 
@@ -16,7 +16,7 @@ Also make sure that the UART where you connected the receiver to doesn't have in
 
 ### Invalid serial RX configuration detected
 
-This is often caused by incorrect Serial RX protocol (should be CRSF), or serialrx_inverted = on (should be off) or serialrx_halfduplex=on (should be off). The Passthrough Init section of the log will show you which setting should be corrected. See this [page](/quick-start/rx-fcprep/) for setting up your Flight Controller.
+This is often caused by incorrect Serial RX protocol (should be CRSF), or serialrx_inverted = on (should be off) or serialrx_halfduplex=on (should be off). The Passthrough Init section of the log will show you which setting should be corrected. See this [page](../../quick-start/rx-fcprep/) for setting up your Flight Controller.
 
 ### RX Serial not found !!!!
 
@@ -32,15 +32,15 @@ This could also mean that the FC cannot be detected by the script. This could al
 
 This can be due to several things:
 
-- Incorrect bootloader is flashed or it's not flashed properly. This mainly happen on the R9 receivers. Go checkout [Bootloader Flashing Guide](/quick-start/rx-bootloader/).
-- Incorrect wiring. Make sure that Rx in the Receiver is connected to a Tx pad in the FC and the Tx in the Receiver is connected to an Rx pad in the FC. Also make sure receiver is getting enough voltage (min 4v5) from the FC or voltage supply. Wiring guide is [here](/quick-start/rx-fcprep/)
+- Incorrect bootloader is flashed or it's not flashed properly. This mainly happen on the R9 receivers. Go checkout [Bootloader Flashing Guide](../../quick-start/rx-bootloader/).
+- Incorrect wiring. Make sure that Rx in the Receiver is connected to a Tx pad in the FC and the Tx in the Receiver is connected to an Rx pad in the FC. Also make sure receiver is getting enough voltage (min 4v5) from the FC or voltage supply. Wiring guide is [here](../../quick-start/rx-fcprep/)
 - Receiver is OFF. Check whether the LED on the receiver is lit, indicating it's powered and in working state.
 - The UART has hardware inversion. Make sure that the UART you've connected the receiver to is not an SBUS UART that's usually have hardware inversion (most common among F4 Flight Controllers). There are Flight controllers that require you bridge a pair of pads to enable or disable the Hardware inversion of an Rx pad. You can simply try a different UART.
 - The LED on the receiver is SOLID, while radio is off, could only mean that the Rx pad in the FC is being pulled LOW, putting the ESP-based receiver (EPs, ES900Rx, etc.) into Bootloader mode unintentionally, which will hinder normal passthrough operations. Feel free to try a different UART.
 
 ### I updated via WiFi but now receiver won't work and has SOLID LED
 
-This is a sign that the Wifi flashing didn't go through properly due to premature power cycle. To fix this, you will have to bridge the boot pads (see [here](/quick-start/rx-fcprep/)) and reflash using the Passthrough method or using an FTDI adapter.
+This is a sign that the Wifi flashing didn't go through properly due to premature power cycle. To fix this, you will have to bridge the boot pads (see [here](../../quick-start/rx-fcprep/)) and reflash using the Passthrough method or using an FTDI adapter.
 
 This video shows the steps albeit using vscode development environment but the ExpressLRS Configurator will work just fine. You might also want to disable Telemetry in Betaflight/emuflight/iNav before attempting recovery.
 

--- a/docs/quick-start/tx-betafpv2400.md
+++ b/docs/quick-start/tx-betafpv2400.md
@@ -8,7 +8,7 @@ template: main.html
 
 Target: `BETAFPV_2400_TX_via_WIFI`
 
-With the correct target selected and [Firmware Options](/quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
 
 The next steps will require the [ELRS Lua Script](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) (right-click, save as). Download the ELRS.lua script and save it to your Radio's `/Scripts/Tools` folder. Insert/attach your module into your module bay and make sure it's not loose and there's proper connection with the radio. Execute the ELRS.lua script by pressing "System Menu" in your radio and then under Tools, select ELRS.lua.
 
@@ -25,7 +25,7 @@ Using your browser, navigate to the correct page (typically http://10.0.0.1/) an
 
 Once the file is uploaded, the webserver should load a White page, with the message **Update Success! Rebooting...**
 
-As it rebooted, the connection to the Webserver got terminated. Check via the Lua Script whether you have successfully updated the TX module. The first line of the lua script should show a 6-character hash that corresponds to the Git commit hash for the firmware version you have on the module. There should be no more "Mismatch" messages as well.
+As it rebooted, the connection to the Webserver got terminated. Verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
 
 ## Flashing via USB/UART
 
@@ -33,9 +33,9 @@ Target: `BETAFPV_2400_TX_via_UART`
 
 Attach a USB Data Cable to your module and Computer. Windows users might have to install [CP210x Drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers) to ensure the device is properly detected and initialized.
 
-Using the ExpressLRS Configurator with the correct Target selected and [Firmware Options](/quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
+Using the ExpressLRS Configurator with the correct Target selected and [Firmware Options](../../quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
 
-Verify with the [ELRS.lua](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
+Verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
 
 ## Can't flash?
 

--- a/docs/quick-start/tx-betafpv900.md
+++ b/docs/quick-start/tx-betafpv900.md
@@ -8,7 +8,7 @@ template: main.html
 
 Target: `BETAFPV_900_TX_via_WIFI`
 
-With the correct target selected and [Firmware Options](/quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
 
 The next steps will require the [ELRS Lua Script](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) (right-click, save as). Download the ELRS.lua script and save it to your Radio's `/Scripts/Tools` folder. Insert/attach your module into your module bay and make sure it's not loose and there's proper connection with the radio. Execute the ELRS.lua script by pressing "System Menu" in your radio and then under Tools, select ELRS.lua.
 
@@ -25,7 +25,7 @@ Using your browser, navigate to the correct page (typically http://10.0.0.1/) an
 
 Once the file is uploaded, the webserver should load a White page, with the message **Update Success! Rebooting...**
 
-As it rebooted, the connection to the Webserver got terminated. Check via the Lua Script whether you have successfully updated the TX module. The first line of the lua script should show a 6-character hash that corresponds to the Git commit hash for the firmware version you have on the module. There should be no more "Mismatch" messages as well.
+As it rebooted, the connection to the Webserver got terminated. Verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
 
 ## Flashing via USB/UART
 
@@ -33,9 +33,9 @@ Target: `BETAFPV_900_TX_via_UART`
 
 Attach a USB Data Cable to your module and Computer. Windows users might have to install [CP210x Drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers) to ensure the device is properly detected and initialized.
 
-Using the ExpressLRS Configurator with the correct Target selected and [Firmware Options](/quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
+Using the ExpressLRS Configurator with the correct Target selected and [Firmware Options](../../quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
 
-Verify with the [ELRS.lua](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
+Verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
 
 ## Can't flash?
 

--- a/docs/quick-start/tx-es24tx.md
+++ b/docs/quick-start/tx-es24tx.md
@@ -8,7 +8,7 @@ template: main.html
 
 Target: `HappyModel_ES24TX_2400_TX_via_WIFI`
 
-With the correct target selected and [Firmware Options](/quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
 
 The next steps will require the [ELRS Lua Script](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) (right-click, save as). Download the ELRS.lua script and save it to your Radio's `/Scripts/Tools` folder. Insert/attach your module into your module bay and make sure it's not loose and there's proper connection with the radio. Execute the ELRS.lua script by pressing "System Menu" in your radio and then under Tools, select ELRS.lua.
 
@@ -25,7 +25,7 @@ Using your browser, navigate to the correct page (typically http://10.0.0.1/) an
 
 Once the file is uploaded, the webserver should load a White page, with the message **Update Success! Rebooting...**
 
-As it rebooted, the connection to the Webserver got terminated. Check via the Lua Script whether you have successfully updated the TX module. The first line of the lua script should show a 6-character hash that corresponds to the Git commit hash for the firmware version you have on the module. There should be no more "Mismatch" messages as well.
+As it rebooted, the connection to the Webserver got terminated. Verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
 
 ## Flashing via USB/UART
 
@@ -41,6 +41,6 @@ This method requires you move two jumpers into specific pins in the module board
 
 The jumpers should be moved into the USB/UART (Green) position from the images above. Attach your USB cable into the module and your computer. [CP210x Drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers) will have to be installed for this to work properly (Windows). Make sure your computer recognizes the module as a USB-to-UART Bridge device, otherwise, this method will not work.
 
-Using the ExpressLRS Configurator with the correct Target selected and [options](/quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
+Using the ExpressLRS Configurator with the correct Target selected and [options](../../quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
 
-Assemble the module back together and attach it to your radio module bay and verify with the [ELRS.lua](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
+Assemble the module back together and attach it to your radio module bay and verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.

--- a/docs/quick-start/tx-es900tx.md
+++ b/docs/quick-start/tx-es900tx.md
@@ -10,7 +10,7 @@ template: main.html
 
 Target: `HappyModel_TX_ES900TX_via_WIFI`
 
-With the correct target selected and [Firmware Options](/quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
 
 The next steps will require the [ELRS Lua Script](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) (right-click, save as). Download the ELRS.lua script and save it to your Radio's `/Scripts/Tools` folder. Insert/attach your module into your module bay and make sure it's not loose and there's proper connection with the radio. Execute the ELRS.lua script by pressing "System Menu" in your radio and then under Tools, select ELRS.lua.
 
@@ -27,7 +27,7 @@ Using your browser, navigate to the correct page (typically http://10.0.0.1/) an
 
 Once the file is uploaded, the webserver should load a White page, with the message **Update Success! Rebooting...**
 
-As it rebooted, the connection to the Webserver got terminated. Check via the Lua Script whether you have successfully updated the TX module. The first line of the lua script should show a 6-character hash that corresponds to the Git commit hash for the firmware version you have on the module. There should be no more "Mismatch" messages as well.
+As it rebooted, the connection to the Webserver got terminated. Verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
 
 ### Flashing via USB
 
@@ -39,9 +39,9 @@ This method requires you move two jumpers into specific pins in the module board
 
 The 2 bottom-most dipswitch should be moved into the position as shown in the image above. Attach your USB cable into the module and your computer. [CP210x Drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers) will have to be installed for this to work properly (Windows). Make sure your computer recognizes the module as a USB-to-UART Bridge device, otherwise, this method will not work.
 
-Using the ExpressLRS Configurator with the correct Target selected and [options](/quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
+Using the ExpressLRS Configurator with the correct Target selected and [options](../../quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
 
-Assemble the module back together and attach it to your radio module bay and verify with the [ELRS.lua](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
+Assemble the module back together and attach it to your radio module bay and verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
 
 ## ES915/868TX (Discontinued)
 

--- a/docs/quick-start/tx-flash2400.md
+++ b/docs/quick-start/tx-flash2400.md
@@ -10,7 +10,7 @@ Target: `NamimnoRC_Flash_2400_TX_via_WiFi`
 
 ### Method 1
 
-With the correct target selected and [Firmware Options](/quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
 
 These Tx Modules are STM32-based so they require a separate ESP "backpack" device for Wifi Flashing/Updating. The `Wifi Update` option in the ExpressLRS Lua script will not work with these devices. The steps that follow will be used instead.
 
@@ -24,7 +24,7 @@ On your browser, refresh the http://elrs_tx.local/ and scroll towards the STM32 
 
 ![STM32 Firmware Update](../assets/images/STM32-updater.png)
 
-Drag-and-drop the `firmware.bin` file created by the ExpressLRS Configurator into the Choose File field, or manually navigate to the Folder by clicking the Choose File button. Once the correct file is selected, click the `Upload and Flash STM32`. Wait for the process to complete, and the module will reboot (~2-3min). Using the [ELRS.lua](/quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
+Drag-and-drop the `firmware.bin` file created by the ExpressLRS Configurator into the Choose File field, or manually navigate to the Folder by clicking the Choose File button. Once the correct file is selected, click the `Upload and Flash STM32`. Wait for the process to complete, and the module will reboot (~2-3min). Using the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
 
 ### Method 2
 
@@ -36,23 +36,23 @@ Attach the module to your JR Bays and power it up. Connect to the `ESP Wifi Mana
 
 Press `Configure WiFi` and set your home network SSID and password. This will enable your Tx Module to connect to your local home network.
 
-Using the ExpressLRS Configurator, select the correct Target and set your [Firmware Options](/quick-start/firmware-options). Click **Build and Flash** and wait for the compile process to complete. You should see a section as pictured below and the Success message marking the update process complete.
+Using the ExpressLRS Configurator, select the correct Target and set your [Firmware Options](../../quick-start/firmware-options). Click **Build and Flash** and wait for the compile process to complete. You should see a section as pictured below and the Success message marking the update process complete.
 
 ![Wifi Update Log](../assets/images/WifiUpdateLog.png)
 
-Using the [ELRS.lua](/quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
+Using the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
 
 ## Flashing via OpenTX Radio
 
 *Note: The `NamimnoRC_Flash_2400_TX_via_WiFi` Target will work for this method too!*
 
-With the correct target selected and [Firmware Options](/quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.elrs` file is. Do not close this window so you can easily locate the correct file to copy to your Radio SD Card.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.elrs` file is. Do not close this window so you can easily locate the correct file to copy to your Radio SD Card.
 
 Copy the `firmware.elrs` file into your radio's SD Card `/FIRMWARE` folder.
 
 Once copied, navigate to the `/FIRMWARE` Folder on your Radio and select/highlight the `firmware.elrs` file, long-press the Enter key and select `Flash external ELRS`. Radio should show a `Flash Successful` message and you're done!
 
-Using the [ELRS.lua](/quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
+Verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
 
 ## Flashing via STLink
 

--- a/docs/quick-start/tx-flash2400.md
+++ b/docs/quick-start/tx-flash2400.md
@@ -52,7 +52,7 @@ Copy the `firmware.elrs` file into your radio's SD Card `/FIRMWARE` folder.
 
 Once copied, navigate to the `/FIRMWARE` Folder on your Radio and select/highlight the `firmware.elrs` file, long-press the Enter key and select `Flash external ELRS`. Radio should show a `Flash Successful` message and you're done!
 
-Verify with the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script if you have successfully updated your module using the Git commit hash for the firmware version you have on the module.
+Using the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
 
 ## Flashing via STLink
 

--- a/docs/quick-start/tx-prep.md
+++ b/docs/quick-start/tx-prep.md
@@ -6,7 +6,7 @@ template: main.html
 
 ## Radio Firmware with CRSFShot/Mixer Sync
 
-ExpressLRS **requires** CRSFShot or Mixer Sync to ensure full support for high packet rates. Starting with [OpenTX-2.3.12](https://www.open-tx.org/2021/06/14/opentx-2.3.12), `CRSFshot` has been fully implemented, and thus you will have to update your OpenTX radio to these newer versions.
+ExpressLRS **requires** CRSFShot or Mixer Sync to ensure full support for high packet rates. Starting with [OpenTX-2.3.12](https://www.open-tx.org/2021/06/14/opentx-2.3.12), `CRSFshot` has been fully implemented, and thus you will have to update your OpenTX radio to these [newer](https://www.open-tx.org/downloads.html#Releases23-ref) versions.
 
 Another alternative is [EdgeTX](https://github.com/EdgeTX/edgetx/releases), the bleeding edge fork of OpenTX.
 
@@ -25,11 +25,11 @@ ExpressLRS uses the CRSF serial protocol to communicate between the transmitter 
 
 ## Serial Baud Rate
 
-On some transmitters, the baud rate for comms between the opentx and the ExpressLRS module can be changed. The two rates available are 115200 and 400000. ExpressLRS supports both rates (auto switches to the correct rate on power-up), however, we have found that on the R9M 2018 modules, the inverter IC's that are used are not capable of reliably handling 400k baud. If you're using an R9M 2018 module, select 115200 baud in OpenTX, or do the resistor mod described on the [R9M 2018 Resistor Mod](https://github.com/ExpressLRS/ExpressLRS/wiki/Inverter-Mod-for-R9M-2018) page.
+On some transmitters, the baud rate for comms between the opentx and the ExpressLRS module can be changed. The two rates available are 115200 and 400000. ExpressLRS supports both rates (auto switches to the correct rate on power-up), however, we have found that on the R9M 2018 modules, the inverter IC's that are used are not capable of reliably handling 400k baud. If you're using an R9M 2018 module, select 115200 baud in OpenTX, or do the resistor mod described on the [R9M 2018 Resistor Mod](../../hardware/inverter-mod/) page.
 
 The QX7, X10/S, X12 will also going to require the [Crossfire Mod](https://blog.seidel-philipp.de/fixed-inverter-mod-for-tbs-crossfire-and-frsky-qx7/) if you're going to use 400k baud rates for use with higher packet rates, particularly with the 2.4G ExpressLRS Modules. Alternatively, EdgeTX can be flashed into these Radios and have OneBit enabled.
 
-The X9D(plus) can't change its Max Bauds settings, but it has been found to be finicky, causing unstable packet transfers, and constant Telemetry Lost/Recovered messages from OpenTX. One fix for this is the use of the OneBit firmware or EdgeTX. Click [here](/hardware/x9d-troubleshooting) for more info.
+The X9D(plus) can't change its Max Bauds settings, but it has been found to be finicky, causing unstable packet transfers, and constant Telemetry Lost/Recovered messages from OpenTX. One fix for this is the use of the OneBit firmware or EdgeTX. Click [here](../../hardware/x9d-troubleshooting) for more info.
 
 ![Baud Rate](https://fpvfrenzy.com/wp-content/uploads/2017/11/baud-rate.jpg)
 

--- a/docs/quick-start/tx-r9m.md
+++ b/docs/quick-start/tx-r9m.md
@@ -15,7 +15,7 @@ Using an `OpenTX` transmitter, you flash the bootloader, and then flash ELRS.
 Here is a quick 2 minute demo if you would rather watch a video than read the steps:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/DG3f-lnNlms" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-With the previous step ([Preparing your Radio](../quick-start/tx-prep.md)) done, you should now readily flash your R9 Transmitter Module.
+With the previous step ([Preparing your Radio](../../quick-start/tx-prep/)) done, you should now readily flash your R9 Transmitter Module.
 
 Copy [`r9m_elrs_bl.frk`](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/bootloader/r9m_elrs_bl.frk?raw=true) onto the SD card of your radio, in the `/FIRMWARE` folder.
 
@@ -32,7 +32,7 @@ Targets:
 - `Frsky_TX_R9M_via_stock_BL`
 - `Frsky_TX_R9M_LITE_via_stock_BL`
 
-In the ExpressLRS Configurator, select the correct target for your module and set your [Firmware Options](/quick-start/firmware-options). 
+In the ExpressLRS Configurator, select the correct target for your module and set your [Firmware Options](../../quick-start/firmware-options). 
 
 Click on **Build** and wait for the firmware to be compiled. After that's done, ExpressLRS Configurator Log should show the `Success` Message, and it will automatically open the folder where the **firmware.elrs** can be found. Put (copy-paste) the firmware.elrs to your Radio's SD Card (preferably to the `/FIRMWARE` folder for easy access). Once on your radio, navigate to the `/FIRMWARE` folder, select the firmware.elrs and click-hold the Enter button and select "Flash External ELRS".
 
@@ -64,6 +64,6 @@ Before flashing, disable `'Readout Protection'`. To do this download the [ST-LIN
 
 <small>R9M Lite Pro STLink Connection</small>
 
-With the module connected shown above, and your [Firmware Options](/quick-start/firmware-options) set, hit **Build & Flash** in the ExpressLRS Configurator and wait for the process to finish. Once that's done, and the Success Message showing, you can now remove/unsolder the STLink, and re-assemble the module, and put it into your Radio's Module Bay. The ExpressLRS tune should play and then two beeps after that can be heard, for units that has a speaker (R9Ms) and if the External Module is set to CRSF Protocol.
+With the module connected shown above, and your [Firmware Options](../../quick-start/firmware-options) set, hit **Build & Flash** in the ExpressLRS Configurator and wait for the process to finish. Once that's done, and the Success Message showing, you can now remove/unsolder the STLink, and re-assemble the module, and put it into your Radio's Module Bay. The ExpressLRS tune should play and then two beeps after that can be heard, for units that has a speaker (R9Ms) and if the External Module is set to CRSF Protocol.
 
 Verification can be done using the ELRS.lua script. It should show the Version Hash at the top, as well as the options you can set. If it's showing "Connecting", check if External Module is set to CRSF for the selected model in your radio, and that internal RF module is set to off. See general Troubleshooting section for other ways to determine your module is flashed and ready for flying.

--- a/docs/quick-start/tx-siyifm30.md
+++ b/docs/quick-start/tx-siyifm30.md
@@ -21,7 +21,7 @@ Attach to an STLink as shown:
 
 ![stlinked](https://github.com/ExpressLRS/ExpressLRS-Hardware/blob/master/img/siyi/jupa/Siyi-5.JPG?raw=true)
 
-With the module connected shown above, and your [Firmware Options](/quick-start/firmware-options) set, hit **Build & Flash** in the ExpressLRS Configurator and wait for the process to finish. Once that's done, and the Success Message showing, you can now remove/unsolder the STLink, and re-assemble the module, and put it into your Radio's Module Bay.
+With the module connected shown above, and your [Firmware Options](../../quick-start/firmware-options) set, hit **Build & Flash** in the ExpressLRS Configurator and wait for the process to finish. Once that's done, and the Success Message showing, you can now remove/unsolder the STLink, and re-assemble the module, and put it into your Radio's Module Bay.
 
 Verification can be done using the ELRS.lua script. It should show the Version Hash at the top, as well as the options you can set. If it's showing "Connecting", check if External Module is set to CRSF for the selected model in your radio, and that internal RF module is set to off. See general Troubleshooting section for other ways to determine your module is flashed and ready for flying.
 

--- a/docs/quick-start/tx-voyager900.md
+++ b/docs/quick-start/tx-voyager900.md
@@ -10,7 +10,7 @@ Target: `NamimnoRC_Voyager_900_TX_via_WiFi`
 
 ### Method 1
 
-With the correct target selected and [Firmware Options](/quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
 
 These Tx Modules are STM32-based so they require a separate ESP "backpack" device for Wifi Flashing/Updating. The `Wifi Update` option in the ExpressLRS Lua script will not work with these devices. The steps that follow will be used instead.
 
@@ -24,7 +24,7 @@ On your browser, refresh the http://elrs_tx.local/ and scroll towards the STM32 
 
 ![STM32 Firmware Update](../assets/images/STM32-updater.png)
 
-Drag-and-drop the `firmware.bin` file created by the ExpressLRS Configurator into the Choose File field, or manually navigate to the Folder by clicking the Choose File button. Once the correct file is selected, click the `Upload and Flash STM32`. Wait for the process to complete, and the module will reboot (~2-3min). Using the [ELRS.lua](/quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
+Drag-and-drop the `firmware.bin` file created by the ExpressLRS Configurator into the Choose File field, or manually navigate to the Folder by clicking the Choose File button. Once the correct file is selected, click the `Upload and Flash STM32`. Wait for the process to complete, and the module will reboot (~2-3min). Using the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
 
 ### Method 2
 
@@ -36,23 +36,23 @@ Attach the module to your JR Bays and power it up. Connect to the `ESP Wifi Mana
 
 Press `Configure WiFi` and set your home network SSID and password. This will enable your Tx Module to connect to your local home network.
 
-Using the ExpressLRS Configurator, select the correct Target and set your [Firmware Options](/quick-start/firmware-options). Click **Build and Flash** and wait for the compile process to complete. You should see a section as pictured below and the Success message marking the update process complete.
+Using the ExpressLRS Configurator, select the correct Target and set your [Firmware Options](../../quick-start/firmware-options). Click **Build and Flash** and wait for the compile process to complete. You should see a section as pictured below and the Success message marking the update process complete.
 
 ![Wifi Update Log](../assets/images/WifiUpdateLog.png)
 
-Using the [ELRS.lua](/quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
+Using the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
 
 ## Flashing via OpenTX Radio
 
 *Note: The `NamimnoRC_Flash_2400_TX_via_WiFi` Target will work for this method too!*
 
-With the correct target selected and [Firmware Options](/quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.elrs` file is. Do not close this window so you can easily locate the correct file to copy to your Radio SD Card.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `firmware.elrs` file is. Do not close this window so you can easily locate the correct file to copy to your Radio SD Card.
 
 Copy the `firmware.elrs` file into your radio's SD Card `/FIRMWARE` folder.
 
 Once copied, navigate to the `/FIRMWARE` Folder on your Radio and select/highlight the `firmware.elrs` file, long-press the Enter key and select `Flash external ELRS`. Radio should show a `Flash Successful` message and you're done!
 
-Using the [ELRS.lua](/quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
+Using the [ELRS.lua](../../quick-start/tx-prep/#troubleshooting-lua-script) script, verify that you have the latest version.
 
 ## Flashing via STLink
 
@@ -69,6 +69,6 @@ Wire your `STLink v2` to the module's pins as show below:
 
 <img src="https://github.com/ExpressLRS/ExpressLRS-Hardware/blob/master/img/namimnopinout.png?raw=true" width="40%">
 
-With the module connected shown above, and your configuration set, hit **Build & Flash** in the ExpressLRS Configurator and wait for the process to finish. Once that's done, and the Success Message showing, you can now remove/unsolder the STLink, and re-assemble the module, and put it into your Radio's Module Bay. If the Radio has CRSF selected, the light should turn green meaning the module has communication with your radio.
+With the module connected shown above, and your [configuration](../../quick-start/firmware-options) set, hit **Build & Flash** in the ExpressLRS Configurator and wait for the process to finish. Once that's done, and the Success Message showing, you can now remove/unsolder the STLink, and re-assemble the module, and put it into your Radio's Module Bay. If the Radio has CRSF selected, the light should turn green meaning the module has communication with your radio.
 
 Verification can be done using the ELRS.lua script. It should show the Version Hash at the top, as well as the options you can set. If it's showing "Connecting", check if External Module is set to CRSF for the selected model in your radio, and that internal RF module is set to off. See general Troubleshooting section for other ways to determine your module is flashed and ready for flying.

--- a/docs/software/user-defines.md
+++ b/docs/software/user-defines.md
@@ -7,7 +7,7 @@ template: main.html
 # User Defines Explained
 With more features being added consistently, [`./src/user_defines.txt`](https://github.com/AlessandroAU/ExpressLRS/blob/master/src/user_defines.txt) has gotten complicated 🤷‍♂️. So we will break it down! 🔨 
 
-*Note: This is the full list of currently supported User Defines and would help you should you intend to compile the firmware using the [Toolchain](/software/toolchain-install/) or Manual Mode on the ExpressLRS Configurator.
+*Note: This is the full list of currently supported User Defines and would help you should you intend to compile the firmware using the [Toolchain](../../software/toolchain-install/) or Manual Mode on the ExpressLRS Configurator.
 
 ## Defines 101
 - To enable/disable anything in the user defines, simply add or remove a `#` in front of anything that has a `-D`.
@@ -66,7 +66,7 @@ Typically, you want to keep **320LU** value for OpenTX based radios, and **100LU
 ```
 #-DHYBRID_SWITCHES_8
 ```
-Changes how the AUX channels are sent over the air. The default option is Normal Mode with 8x 2-position low-latency switches. Enabling `HYBRID_SWITCHES_8` changes this to 1x 2-pos + 6x 7-pos + 1x 16-pos, with only the 2-position being low-latency. In Normal Mode, all switches are sent with every packet, in Hybrid Mode, only AUX1 is sent with every packet and the rest are rotated through. Note: The switch mode MUST match between the RX and TX. A detailed explanation of the differences between the two options can be found in [Switch Modes](https://github.com/ExpressLRS/ExpressLRS/wiki/Switch-Modes), but
+Changes how the AUX channels are sent over the air. The default option is Normal Mode with 8x 2-position low-latency switches. Enabling `HYBRID_SWITCHES_8` changes this to 1x 2-pos + 6x 7-pos + 1x 16-pos, with only the 2-position being low-latency. In Normal Mode, all switches are sent with every packet, in Hybrid Mode, only AUX1 is sent with every packet and the rest are rotated through. Note: The switch mode MUST match between the RX and TX. A detailed explanation of the differences between the two options can be found in [Switch Modes](../../software/switch-config/), but
   1. If only two position switches are needed, and they must be updated as fast as possible: Normal Mode
   2. Almost everyone: Hybrid Mode (Put ARM on AUX1)
 
@@ -76,7 +76,7 @@ There has been some reports of the R9M modules showing instability at >250mw wit
 ````
 #-DUNLOCK_HIGHER_POWER 
 ````
-We published [R9M Fan Mod Cover](https://github.com/AlessandroAU/ExpressLRS/wiki/R9M-Fan-Mod-Cover), a custom 3d printed backplate with room for a fan and extra cooling to allow for maximum power (1-2W depending on the mod).
+We published [R9M Fan Mod Cover](../../hardware/fan-mod/), a custom 3d printed backplate with room for a fan and extra cooling to allow for maximum power (1-2W depending on the mod).
  
 <img src="https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/STL/R9M-Fan-Mod-Case/view-top.png" data-canonical-src="https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/STL/R9M-Fan-Mod-Case/view-top.png" width="20%" height="auto" /><img src="https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/STL/R9M-Fan-Mod-Case/view-bottom.png" data-canonical-src="https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/STL/R9M-Fan-Mod-Case/view-bottompng" width="20%" height="auto" />
 
@@ -148,8 +148,8 @@ The build process also supports RTTTL-formatted ringtone strings. RTTTL melodies
 ```
 -DUSE_ESP8266_BACKPACK
 ```
-This enables communication with the **[ESP Backpack](/hardware/esp-backpack)** for over-the-air updates (`env:FrSky_TX_R9M_via_WiFi`) 🖥️ and debugging via WebSocket 🔍. Uncommented by default, does not need to be changed.
+This enables communication with the **[ESP Backpack](../../hardware/esp-backpack)** for over-the-air updates (`env:FrSky_TX_R9M_via_WiFi`) 🖥️ and debugging via WebSocket 🔍. Uncommented by default, does not need to be changed.
 
 ## Obsolete user_defines
 
-See [Obsolete user_defines](/software/obsolete-defines)
+See [Obsolete user_defines](../../software/obsolete-defines)


### PR DESCRIPTION
internal links now uses `../../<slug>` instead of `/<slug>` in preparation for mike implementation

Please test for any broken links, both with mike or without mike

Images seems to resolve and load properly on my side, both with mike running or with just docker

Thanks!