### PR TITLE
Happymodel ES24TX Slim Pro

### DIFF
--- a/docs/quick-start/tx-es24tx.md
+++ b/docs/quick-start/tx-es24tx.md
@@ -6,7 +6,10 @@ template: main.html
 
 ## Flashing via WiFi
 
-Target: `HappyModel_ES24TX_2400_TX_via_WIFI`
+Targets:
+
+- `HappyModel_ES24TX_2400_TX_via_WIFI`
+- `HappyModel_ES24TX_Slim_Pro_2400_TX_via_WIFI`
 
 With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `HappyModel_ES24TX_2400_TX-<version>.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
 
@@ -29,7 +32,10 @@ As it rebooted, the connection to the Webserver got terminated. Verify with the 
 
 ## Flashing via USB/UART
 
-Target: `HappyModel_ES24TX_2400_TX_via_UART`
+Targets:
+
+- `HappyModel_ES24TX_2400_TX_via_UART`
+- `HappyModel_ES24TX_Slim_Pro_2400_TX_via_UART`
 
 This method requires you move two jumpers into specific pins in the module board. See the following image for the jumper location and which pin should be bridged for this method to work.
 
@@ -40,6 +46,8 @@ This method requires you move two jumpers into specific pins in the module board
 ![JumperSlim](../assets/images/Jumper-slim.jpg)
 
 The jumpers should be moved into the USB/UART (Green) position from the images above. Attach your USB cable into the module and your computer. [CP210x Drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers) will have to be installed for this to work properly (Windows). Make sure your computer recognizes the module as a USB-to-UART Bridge device, otherwise, this method will not work.
+
+*Note: The new Slim Pro doesn't have jumpers or dip switches that you need to move in order to flash via USB. Just connect USB and make sure your computer has recognized the device as a USB-to-UART Bridge (i.e. install the needed CP210x drivers).*
 
 Using the ExpressLRS Configurator with the correct Target selected and [options](../../quick-start/firmware-options) set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
 

--- a/docs/quick-start/tx-es24tx.md
+++ b/docs/quick-start/tx-es24tx.md
@@ -11,7 +11,7 @@ Targets:
 - `HappyModel_ES24TX_2400_TX_via_WIFI`
 - `HappyModel_ES24TX_Slim_Pro_2400_TX_via_WIFI`
 
-With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `HappyModel_ES24TX_2400_TX-<version>.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
+With the correct target selected and [Firmware Options](../../quick-start/firmware-options) set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `HappyModel_ES24TX_2400_TX-<version>.bin` or `HappyModel_ES24TX_Slim_Pro_2400_TX-<version>.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
 
 The next steps will require the [ELRS Lua Script](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/ELRS.lua?raw=true) (right-click, save as). Download the ELRS.lua script and save it to your Radio's `/Scripts/Tools` folder. Insert/attach your module into your module bay and make sure it's not loose and there's proper connection with the radio. Execute the ELRS.lua script by pressing "System Menu" in your radio and then under Tools, select ELRS.lua.
 
@@ -24,7 +24,7 @@ At first, it will show "Mismatch"; it's normal. Tap `Enter` once on your radio t
 
 Select "Wifi Update" from the lua script. The Lua script will instruct you to go to a specific Ip Address, but you have to first connect to the Wifi Hotspot it created. It will show up in your network as `ExpressLRS TX Module`, and the password is simply `expresslrs`.
 
-Using your browser, navigate to the correct page (typically http://10.0.0.1/) and it should show an upload form (you will have to scroll down a bit). You can drag-and-drop the `HappyModel_ES24TX_2400_TX-<version>.bin` file from the folder that ExpressLRS Configurator opened for you, or you can manually navigate to it via the `Browse` or `Choose File` button on the Upload form. Click on `Update` once and the update process should commence. Take note that you should be taking a **TX** firmware file. The folder name where you can get this file is the same as the Target you have selected in the ExpressLRS Configurator.
+Using your browser, navigate to the correct page (typically http://10.0.0.1/) and it should show an upload form (you will have to scroll down a bit). You can drag-and-drop the `HappyModel_ES24TX_2400_TX-<version>.bin` or `HappyModel_ES24TX_Slim_Pro_2400_TX-<version>.bin` file from the folder that ExpressLRS Configurator opened for you, or you can manually navigate to it via the `Browse` or `Choose File` button on the Upload form. Click on `Update` once and the update process should commence. Take note that you should be taking a **TX** firmware file. The folder name where you can get this file is the same as the Target you have selected in the ExpressLRS Configurator.
 
 Once the file is uploaded, the webserver should load a White page, with the message **Update Success! Rebooting...**
 


### PR DESCRIPTION
This PR adds info for the Happymodel ES24TX Slim Pro.

This doesn't add a new page, as these modules are flashed the same way as the regular ES24TX modules, sans jumper or dip switches.

(Note: The targets for these ES24TX aren't in the 1.0.4 Configurator yet, as well as with the 1.0.1 version of the firmware. Please merge once those updates are released.)