### PR TITLE
Add RF Mode Indexes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,7 +65,7 @@ No, just like what channel your VTX is on is not a secret. The binding phrase is
 | 2RSS | Uplink - received signal strength antenna 2 (RSSI)   |           | Second antenna RSSI, used in diversity mode |
 | ANT  | RX active antenna                                    | 0 - 1     | Active antenna for diversity RX |
 | RSNR | Uplink - signal-to-noise ratio                       |           | SNR reported by the RX. Value varies mostly by radio chip and gets lower with distance (once the agc hits its limit)|
-| RFMD | Uplink - packet rate                                 | 0 - 7     | [RF Mode Indexes](../info/signal-health.md#rf-mode-indexes-rfmd) |
+| RFMD | Uplink - packet rate                                 | 0 - 7     | [RF Mode Indexes](../info/signal-health/#rf-mode-indexes-rfmd) |
 | TPWR | Uplink - transmitting power                          |           | 50mW reported as 0, as CRSF/OpenTX do not have this option |
 | TQly | Downlink - link quality (valid packets)              |  0 - 100  | An LQ indicator of telemetry packets received RX → TX |
 | TRSS | Downlink - received signal strength (RSSI)           |           | RSSI dBm of telemetry packets received by TX |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,7 +65,7 @@ No, just like what channel your VTX is on is not a secret. The binding phrase is
 | 2RSS | Uplink - received signal strength antenna 2 (RSSI)   |           | Second antenna RSSI, used in diversity mode |
 | ANT  | RX active antenna                                    | 0 - 1     | Active antenna for diversity RX |
 | RSNR | Uplink - signal-to-noise ratio                       |           | SNR reported by the RX. Value varies mostly by radio chip and gets lower with distance (once the agc hits its limit)|
-| RFMD | Uplink - packet rate                                 | 0 - 7     | [RF Mode Indexes](../info/signal-health.md) |
+| RFMD | Uplink - packet rate                                 | 0 - 7     | [RF Mode Indexes](../info/signal-health.md#rf-mode-indexes-rfmd) |
 | TPWR | Uplink - transmitting power                          |           | 50mW reported as 0, as CRSF/OpenTX do not have this option |
 | TQly | Downlink - link quality (valid packets)              |  0 - 100  | An LQ indicator of telemetry packets received RX → TX |
 | TRSS | Downlink - received signal strength (RSSI)           |           | RSSI dBm of telemetry packets received by TX |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,13 +63,13 @@ No, just like what channel your VTX is on is not a secret. The binding phrase is
 | RQly | Uplink - link quality (valid packets)                |  0 - 100  | The number of successful packets out of the last 100 from TX → RX |
 | 1RSS | Uplink - received signal strength antenna 1 (RSSI)   | -128 - 0  | RSSI dBm as reported by the RX. Values vary depending on mode, antenna quality, output power and distance |
 | 2RSS | Uplink - received signal strength antenna 2 (RSSI)   |           | Second antenna RSSI, used in diversity mode |
-| ANT  | RX active Antenna                                    |           | Not populated currently |
+| ANT  | RX active antenna                                    | 0 - 1     | Active antenna for diversity RX |
 | RSNR | Uplink - signal-to-noise ratio                       |           | SNR reported by the RX. Value varies mostly by radio chip and gets lower with distance (once the agc hits its limit)|
-| RFMD | Uplink - update rate                                 |           |  |
+| RFMD | Uplink - packet rate                                 | 0 - 7     | [RF Mode Indexes](../info/signal-health.md) |
 | TPWR | Uplink - transmitting power                          |           | 50mW reported as 0, as CRSF/OpenTX do not have this option |
 | TQly | Downlink - link quality (valid packets)              |  0 - 100  | An LQ indicator of telemetry packets received RX → TX |
 | TRSS | Downlink - received signal strength (RSSI)           |           | RSSI dBm of telemetry packets received by TX |
-| TSNR | Downlink - signal-to-noise ratio                     |           | SNR reported by the radio in the TX module when receiving telemetry packets |
+| TSNR | Downlink - signal-to-noise ratio                     |           | SNR reported by the TX for telemetry packets |
 
 
 ## Is it normal to get "RF Signal Critical" when plugging in?

--- a/docs/info/signal-health.md
+++ b/docs/info/signal-health.md
@@ -43,6 +43,20 @@ What appears in the RSSI Value field is based on what is selected as the RSSI Ch
 
 In iNAV, the RSSI Value on the OSD is called RSSI (Signal Strength), and will always display 0. To show a filtered (by iNav) LQI in that field, set the rssi_source to protocol using the CLI with `set rssi_source = PROTOCOL`.
 
+## RF Mode Indexes (RFMD)
+OSDs report the packet rate using an index instead of the actual rate, either as a `RATE:LQ%` or with rate in the hundreds digit such as `799` where 7 is the RATE and 99 is the LQ%. Handsets display the rate using the RFMD telemetry item.
+
+![OSD RFMD](https://cdn.discordapp.com/attachments/738450139693449258/886313969638334484/unknown.png)
+| RFMD | Packet Rate | Sensitivity Limit | TX duration (us) | TX Interval (us) |
+|---|---|---|---|---|
+| 7 | 500Hz | -105dBm | 1665 | 2000 |
+| 6 | 250Hz | -108dBm | 3300 | 4000 |
+| 5 | 200Hz | -112dBm | 4380 | 5000 |
+| 4 | 150Hz | -112dBm | 5871 | 6000 |
+| 3 | 100Hz | -117dBm | 8770 | 10000 |
+| 2 | 50Hz | -120dBm (900) / -117dBm (2.4) | 17540 (900) / 18443 (2.4) | 20000 |
+| 1 | 25Hz | -123dBm | 19732 | 40000 |
+
 ## What about SNR?
 
 Wow look at you smarty pants! SNR stands for Signal to Noise ratio and compares RSSI dBm to the RF background noise level and is in dB units (not dBm). Notice it compares the background noise level and not the Sensitivity Limit. The value is of limited usefulness because the RF chip can only approximate the noise level and can only register a value so high above it leading to this value getting clipped. Add to that, LoRa modulation can actually receive data **below the noise floor** to some degree, so just ignore this number really, but positive values are better.


### PR DESCRIPTION
Adds a table of the RF Mode indexes used in the OSD and RFMD telemetry. I'd like to link directly to the table from the FAQ entry about it, but I am not sure how the HTML anchor will end up so I think just the page is OK?

### Extras
* ANT is populated now in 2.0