### PR TITLE
Add RCVR_INVERT_TX documentation

### DIFF
--- a/docs/quick-start/firmware-options.md
+++ b/docs/quick-start/firmware-options.md
@@ -67,7 +67,13 @@ USE_R9MM_R9MINI_SBUS
 ```
 On the R9MM/R9Mini only, this changes the pin used to output CRSF from the receiver the two side pins (A9 and A10) to the pin labeled "SBUS" on the RX, which is inverted. Similar to `RCVR_INVERT_TX` this does not convert the output to SBUS protocol, so CRSF should still be the receiver protocol selected in the flight controller software.
 
-### Should I turn these off?
+### Should I turn these off/on?
+
+```
+NO_SYNC_ON_ARM
+```
+Sync packets are one packet out of every 5 seconds when armed. Leave this off unless running telemetry ratio Off because you won't be able to reconnect after a failsafe while armed if this is on.
+
 ```
 LOCK_ON_FIRST_CONNECTION
 ```

--- a/docs/quick-start/firmware-options.md
+++ b/docs/quick-start/firmware-options.md
@@ -116,6 +116,11 @@ USE_DIVERSITY
 Enable antenna-switching diversity for Receivers that support it.
 
 ```
+RCVR_INVERT_TX
+```
+ESP-based receivers only, invert the TX pin output to generate inverted CRSF. For connecting to a flight controller that only has an RXI / SBUS (RX inverted) pad.
+
+```
 USE_R9MM_R9MINI_SBUS
 ```
 **This does not turn on SBUS protocol** it simply changes the pin used for communication from those two side pins (A9 and A10) to use the pin labeled "SBUS" on the RX, which is inverted. This is useful for F4 FCs which only have an inverted receiver input UART RX. 🔼. This is only one way, so you lose the telemetry downlink to your radio as well as passthrough flashing. Enabling this turns on CRSF protocol output on the S.BUS 🚌 pin on your R9MM/R9Mini. set serialrx_inverted = ON may also be needed within Betaflight 🐝 for compatibility

--- a/docs/quick-start/firmware-options.md
+++ b/docs/quick-start/firmware-options.md
@@ -4,7 +4,7 @@ template: main.html
 
 ![Setup-Banner](https://github.com/ExpressLRS/ExpressLRS-Hardware/raw/master/img/quick-start.png)
 
-This page aims to explain which options to set on the ExpressLRS Configurator for a particular Hardware. It helps guide you through which options you should enable for your purposes or which options should be left at default.
+This page aims to explain only the key options in ExpressLRS Configurator you may need for your initial setup. For a full description of **all** the options available, see the [User Defines page](../../software/user-defines/).
 
 Some of these options are present on both the Tx and Rx Targets. It is important that these options match to both the TX module and receiver in order for them to bind. `team2400` and `team900` also share a few options and some options are unique to that frequency band. Shown below are common options available on `team2400` and `team900` TXes respectively.
 
@@ -19,78 +19,31 @@ Regulatory_Domain_EU_868
 Regulatory_Domain_FCC_915
 Regulatory_Domain_ISM_2400
 ```
-This is a relatively simple one - enable whatever regulatory domain you are in. `EU 868` is compliant to the frequency but **is not** LBT compliant 👂 . Every other band is near compliant 👿  but may not be fully compliant for your regulatory domain. 
+This is a relatively simple one - enable whatever regulatory domain you are in to select the frequency range to be used. `EU 868` is compliant to the frequency but **is not** LBT compliant 👂.
 
 ## Binding Phrase
 
-This step is simple but **important**. Both the TX and RX NEED to have the same binding phrase or **ExpressLRS WILL NOT WORK**. Anyone using the same binding phrase as you will be able to control your model, so be unique. Set something memorable, and limit to alphanumeric phrases conforming to the Latin alphabet. Receivers flashed with firmware builds that do not have binding phrase enabled will support and require the traditional [binding method](../../quick-start/binding/). 📜 
-
-## Performance Options
-```
-NO_SYNC_ON_ARM
-```
-**no sync on arm** doesn't transmit sync packets while armed. This is useful for racing as there is less time & packets wasted 🗑️ on sending sync packets. **HOWEVER** if you are doing serious long range ⛰️, keep this commented because in the case of a sustained failsafe, link can not be regained while armed.
-
-AUX1 is the channel ExpressLRS uses to detect "ARMED", and this feature assumes that a **low value of the arm switch is disarmed, and a high value is armed**. OpenTX can invert your switch if you prefer it to be mechanically inverted. It may be best not to enable no sync on arm when you are first setting up ExpressLRS as it can be a source of confusion.
-
-```
-FEATURE_OPENTX_SYNC
-```
-This option enables **lower latency** 🏃‍♂️ from the OpenTX radio to the TX and should be kept enabled. To get the full benefit of the option, you should be running an OpenTX version with CRSFShot or Mixer Sync enabled.
-
-## Extra Data
-
-```
-TLM_REPORT_INTERVAL_MS
-```
-It makes the TX module send the telemetry data to OpenTX to the interval you set. This stops the telemetry lost warnings when running a high telemetry ratio, or low rates like 50hz.
-     
-Default value is **320LU**. If you want to change that you have to suffix your milliseconds value with **LU**. For example, in order to specify 100 ms telemetry update rate you have to enter it like this: **100LU**.
-
-Typically, you want to keep **320LU** value for OpenTX based radios, and **100LU** for ErskyTx ones.
-
-*Tip: only check this if you're changing the value. No need to enable it if you'll be using the default 320LU value*
+Entering a binding phrase allows you to skip the binding step with your receivers-- you want this set. Any transmitter using the same binding phrase will connect to any receiver with the same binding phrase, so be unique. Limit to alphanumeric phrases conforming to the Latin alphabet. Receivers flashed with firmware builds that do not have binding phrase enabled will require traditional [binding method](../../quick-start/binding/).
 
 ## Network Options
-
-```
-AUTO_WIFI_ON_INTERVAL
-```
-*Note: In version 2.0, this option became available for Transmitter Modules.*
-
-⚠️ Must be defined if you plan to update your RX over wifi without using a button on the RX ⚠️ This will automatically turn the wifi 📶 ON for any module that has an ESP8285 on it if no TX connection is established after N seconds from boot (Factory Firmware of the HappyModel receivers set this to the previous default of 20s. RC8 has increased the interval to 30s). This enables pushing firmware updates to the RX by connecting to its wifi network and visiting http://10.0.0.1.
 
 ```
 HOME_WIFI_SSID
 HOME_WIFI_PASSWORD
 ```
-*New in 2.0*
-
-These options set Home Network Access for your Wifi-enabled hardware. With these set, the devices will connect to your WiFi Network when you click on "(Wifi) Update" on the ExpressLRS Lua script (for some Tx Modules) or automatically after your set interval time (Receivers). Once the devices connect to your Home WiFi, the Update page can be accessed anywhere, in any device in the same network. Tx Module Wifi update page can be reached using the address http://elrs_tx.local, while receivers' update page can be reached via http://elrs_rx.local.
+Set these to have the "Wifi Update" mode try to connect to an existing wifi network first using these credentials before creating an access point. Configure them with the wifi settings for where you'll be flashing your firmware, to save the step of switching wifi networks during the flashing process.
 
 ## Other Options
 
 ```
-JUST_BEEP_ONCE
-DISABLE_STARTUP_BEEP
-MY_STARTUP_MELODY="<music string>|<bpm>|<semitone offset>"
-```
-For TXes like the R9M, this sets if the TX only beeps one-time, not beep at all or play custom a startup song. By default it is set to play the ExpressLRS Startup Tune 🎼 , but if you don't prefer it, or simply want to go stealthy, enable any of these options. ✖️
- 
-For all your customization needs, use `MY_STARTUP_MELODY` to define your own startup melody using either the BlHeli32 syntax or RTTL. 
-The BlHeli32 Synatax has the required parameters `music string` and `bpm`, and `semitone offset` is optional to transpose the entire melody up or down by the defined amount of semitones. Example BlHeli32 melodies are available on [Rox Wolfs youtube channel](https://www.youtube.com/playlist?list=PL_O0XT_1mZinetucKyuBUvkju8P7DEg-v), some experimentation may be required though. :musical_note: To write your own melody, **[this (Sheet Music 101)](https://github.com/nseidle/AxelF_DoorBell/wiki/How-to-convert-sheet-music-into-an-Arduino-Sketch)** and **[this (BLHeli Piano)](https://dra6n.github.io/blhelikeyboard.github.io/)** are useful resources.
-
-The RTTL Syntax is the same as used in old mobil phones for ringtones and some examples of it can be found [here](http://esctunes.com/), where you can search through many existing RTTL melodies.
-
-```
 UNLOCK_HIGHER_POWER 
 ```
-Majority of the ExpressLRS modules maxes out at 250mW. With this option, higher power levels can be unlocked on the modules that supports it. However, it is imperative that you have taken measures to provide ample cooling to the module's internals through the use of a [Fan Mod](../../hardware/fan-mod/). This specifically applies to the R9M, which, from factory, supports a higher power level up to 1W; but because ExpressLRS runs at a much higher duty cycle, it taxes the circuity and thus produces heat much earlier. To keep it stable, cooling should be implemented. Without any cooling, you run the risk of ending up with a red paperweight.
+Enables higher output power for devices that support it but will possibly melt themselves to give it to you. Do not enable it without first updating your cooling setup or verifying the device isn't overheating when running at your chosen power.
 
 ```
 UART_INVERTED
 ```
-This **only works** with ESP based TXes (will not work with modules without built-in inversion/uninversion), but enables compatibility with radios that output inverted CRSF, such as the FrSky QX7, TBS Tango 2, RadioMaster TX16S. You want to keep this enabled in most of the cases. If your radio is T8SG V2 or you use Deviation firmware turn this setting off.
+This **only works** with ESP32 based TXes. **Almost all handsets** require `UART_INVERTED` on, such as the FrSky QX7, TBS Tango 2, and RadioMaster TX16S. For T8SG V2 or Deviation firmware turn this setting off.
 
 ## Receiver Only Options ##
 
@@ -98,32 +51,34 @@ This **only works** with ESP based TXes (will not work with modules without buil
 
 ![900 RX Options](../assets/images/ConfigurationOptions900rx.jpg)
 
-*Note: Configuration of the Receivers should match the configuration of the Transmitter Module for Sync/Binding to happen between devices.*
+*Note: Configuration of Receivers should match the configuration of the Transmitter Module for Sync/Binding to happen between devices.*
 
-The explanation of the options for the Transmitter Modules also apply for the Receivers.
+Most of the options listed above also apply to Receivers, receivers have a few extra options that you may need.
 
-But here's a few Receiver-specific Options you can configure:
-
-```
-LOCK_ON_FIRST_CONNECTION
-```
-RF Mode Locking - When the RX is waiting for a connection, it cycles through all available rates waiting for a connection on each one. By default, ExpressLRS will go back to this mode after a disconnect (failsafe). If LOCK_ON_FIRST_CONNECTION is used, ELRS will not cycle after a disconnect, but instead just stay on whatever rate the last connection was. This makes connection re-establishment quick, because the RX is always listening at the proper rate. This is generally what everyone wants, but there is utility in being able to switch the TX to the lowest rate to get more range to re-establish a link with a downed model, which can't happen if the RX is locked at the previous rate.
-When cycling through the rates, the RX starts with the fastest packet rate and works down to the slowest, then repeats. It waits PACKET_INTERVAL * PACKS_PER_HOP * HOP_COUNT * 1.1 at each rate. Example: 4ms * 4 * 80 * 1.1 = 1.408s for 250Hz. The duration is extended 10x if a valid packet is received during that time. Even with LOCK_ON_FIRST_CONNECTION, the rate can be changed by changing the TX rate using ELRS.lua while connected, or by power cycling the RX.
-
-```
-USE_DIVERSITY
-```
-Enable antenna-switching diversity for Receivers that support it.
+### Output Inverting
 
 ```
 RCVR_INVERT_TX
 ```
-ESP-based receivers only, invert the TX pin output to generate inverted CRSF. For connecting to a flight controller that only has an RXI / SBUS (RX inverted) pad.
+If using an a flight controller that **only** has an RXI / SBUS (RX inverted) pad, turn on this option to invert the CRSF output from the receiver to be able to use that pad. This does not convert the output to SBUS, it is inverted CRSF, so CRSF should still be the receiver protocol selected in the flight controller software. ESP-based receivers only.
 
 ```
 USE_R9MM_R9MINI_SBUS
 ```
-**This does not turn on SBUS protocol** it simply changes the pin used for communication from those two side pins (A9 and A10) to use the pin labeled "SBUS" on the RX, which is inverted. This is useful for F4 FCs which only have an inverted receiver input UART RX. 🔼. This is only one way, so you lose the telemetry downlink to your radio as well as passthrough flashing. Enabling this turns on CRSF protocol output on the S.BUS 🚌 pin on your R9MM/R9Mini. set serialrx_inverted = ON may also be needed within Betaflight 🐝 for compatibility
+On the R9MM/R9Mini only, this changes the pin used to output CRSF from the receiver the two side pins (A9 and A10) to the pin labeled "SBUS" on the RX, which is inverted. Similar to `RCVR_INVERT_TX` this does not convert the output to SBUS protocol, so CRSF should still be the receiver protocol selected in the flight controller software.
+
+### Should I turn these off?
+```
+LOCK_ON_FIRST_CONNECTION
+```
+Keeps the receiver on the last packet rate it was on if it failsafes, instead of trying every packet rate to reconnect. Should be left on.
+
+```
+USE_DIVERSITY
+```
+Enable diversity for Receivers that support it, but safe to leave on for hardware that doesn't have diversity.
+
+## Full List
 
 *For a complete list of User Defines, head over to the [User Defines page](../../software/user-defines/).*
 

--- a/docs/software/obsolete-defines.md
+++ b/docs/software/obsolete-defines.md
@@ -47,6 +47,13 @@ This enables 500Hz mode for 2.4 GHz RXes and TXes. The drawback is that you have
 **REMOVED** 1.0.0-RC9, this option is now always enabled and in turn, 25Hz has been dropped/removed.
 
 ```
+-DUSE_UART2
+```
+This enables integration with Jye's **[FENIX rx5805 pro-diversity module](https://github.com/JyeSmith/FENIX-rx5808-pro-diversity)**
+
+**REMOVED** Somewhere in the 1.0.0-RC cycle. Feature removed.
+
+```
 -DFAST_SYNC
 ```
 Option that adds faster initial syncing, by changing how long the receiver waits for a connection in each mode while not connected. This option is now the default, but disabling it can help syncing at lower packet rates (50Hz and below).

--- a/docs/software/user-defines.md
+++ b/docs/software/user-defines.md
@@ -10,30 +10,32 @@ With more features being added consistently, [`./src/user_defines.txt`](https://
 *Note: This is the full list of currently supported User Defines and would help you should you intend to compile the firmware using the [Toolchain](../../software/toolchain-install/) or Manual Mode on the ExpressLRS Configurator.
 
 ## Defines 101
-- To enable/disable anything in the user defines, simply add or remove a `#` in front of anything that has a `-D`.
-- We recommend reading this page **in its entirety** before first flashing ⚡ to have a better sense of the options.
+- If these are used in Configurator Manual Mode or user_defines.txt, the value must begin with `-D`. Example: `NO_SYNC_ON_ARM` would be `-DNO_SYNC_ON_ARM`.
+- A user define that begins with `#` is "commented out", i.e. not active.
 
 ## Binding Phrase
 ```
--DMY_BINDING_PHRASE="default ExpressLRS binding phrase"
+MY_BINDING_PHRASE="default ExpressLRS binding phrase"
 ```
-This step is simple but **important**. Both the TX and RX NEED to have the same binding phrase or **ExpressLRS WILL NOT WORK**. Anyone using the same binding phrase as you will be able to control your model, so be unique. Set something memorable, and limit to alphanumeric phrases conforming to the Latin alphabet<sup>*</sup>. Receivers flashed with firmware builds that do not have binding phrase enabled will support and require the traditional binding method. 📜 
+This step is simple but **important**. Both the TX and RX NEED to have the same binding phrase or **ExpressLRS WILL NOT WORK**. Anyone using the same binding phrase as you will be able to control your model, so be unique. Set something memorable, and limit to alphanumeric phrases conforming to the Latin alphabet<sup>*</sup>. Receivers flashed with firmware builds that do not have binding phrase enabled will support and require the traditional binding method. 📜
+
+This feature can, but should not be used as a model match feature (to lock a single specific transmitter to a single specific receiver). For that use, the [Model Match option](../model-config-match/#model-match).
 
 <small><sup>*</sup> This phrase gets md5 hashed and gets built into the binary you will be flashing.</small>
 
 ## Regulatory Domain
 ```
-#-DRegulatory_Domain_AU_915
-#-DRegulatory_Domain_EU_868
-#-DRegulatory_Domain_AU_433
-#-DRegulatory_Domain_EU_433
-#-DRegulatory_Domain_FCC_915
-#-DRegulatory_Domain_ISM_2400
+Regulatory_Domain_AU_915
+Regulatory_Domain_EU_868
+Regulatory_Domain_AU_433
+Regulatory_Domain_EU_433
+Regulatory_Domain_FCC_915
+Regulatory_Domain_ISM_2400
 ```
 This is a relatively simple one - enable whatever regulatory domain you are in. `EU 868` 🇪🇺  is compliant to the frequency but **is not** LBT compliant 👂 . Every other band is near compliant 👿  but may not be fully compliant for your regulatory domain. 
 
 ```
-#-DTLM_REPORT_INTERVAL_MS=320LU
+TLM_REPORT_INTERVAL_MS=320LU
 ```
 It makes the TX module send the telemetry data to the OpenTX every 320 ms by default. This stops the telemetry lost warnings when running a high telemetry ratio, or low rates like 50hz.
      
@@ -45,7 +47,7 @@ Typically, you want to keep **320LU** value for OpenTX based radios, and **100LU
 There has been some reports of the R9M modules showing instability at >250mw with stock cooling. This in part because the ELRS uses a higher duty cycle for transmission compared to stock firmware. By default the power of any TX is limited to 250mw but you can unlock up to 1000mw (for hardware that supports it) by enabling the following option. Do this at your own risk if you make no cooling modifications-- R9M modules will burn themselves out without cooling.
 
 ````
-#-DUNLOCK_HIGHER_POWER 
+UNLOCK_HIGHER_POWER 
 ````
 We published [R9M Fan Mod Cover](../../hardware/fan-mod/), a custom 3d printed backplate with room for a fan and extra cooling to allow for maximum power (1-2W depending on the mod).
  
@@ -53,15 +55,15 @@ We published [R9M Fan Mod Cover](../../hardware/fan-mod/), a custom 3d printed b
 
 ## Performance Options
 ```
-#-DNO_SYNC_ON_ARM
+NO_SYNC_ON_ARM
 ```
 **no sync on arm** doesn't transmit sync packets while armed. This is useful for racing as there is less time & packets wasted 🗑️ on sending sync packets. **HOWEVER** if you are doing serious long range ⛰️, keep this commented because in the case of a sustained failsafe, link can not be regained while armed.
 
 AUX1 is the channel ExpressLRS uses to detect "ARMED", and this feature assumes that a **low value of the arm switch is disarmed, and a high value is armed**. OpenTX can invert your switch if you prefer it to be mechanically inverted. It may be best not to enable no sync on arm when you are first setting up ExpressLRS as it can be a source of confusion.
  
 ```
--DFEATURE_OPENTX_SYNC
-#-DFEATURE_OPENTX_SYNC_AUTOTUNE
+FEATURE_OPENTX_SYNC
+FEATURE_OPENTX_SYNC_AUTOTUNE
 ```
 These features enable **lower latency** 🏃‍♂️ and **offset** from the OpenTX radio to the TX. The first lowers latency and should be kept enabled. The second is more experimental and can lower the offset from the radio by tuning it as close as possible to `0`, but is experimental (even in 1.0) and is best left disabled. 
 
@@ -72,43 +74,43 @@ Deviation radio users such as those with the T8SGv2/v3 should disable this featu
 You can also use [EdgeTX](https://github.com/EdgeTX/edgetx).
 
 ```
--DLOCK_ON_FIRST_CONNECTION
+LOCK_ON_FIRST_CONNECTION
 ```
 RF Mode Locking - When the RX is waiting for a connection, it cycles through all available rates waiting for a connection on each one. By default, ExpressLRS will go back to this mode after a disconnect (failsafe). If `LOCK_ON_FIRST_CONNECTION` is used, ELRS will not cycle after a disconnect, but instead just stay on whatever rate the last connection was. This makes connection re-establishment quick, because the RX is always listening at the proper rate. This is generally what everyone wants, but there is utility in being able to switch the TX to the lowest rate to get more range to re-establish a link with a downed model, which can't happen if the RX is locked at the previous rate.
 
 When cycling through the rates, the RX starts with the fastest packet rate and works down to the slowest, then repeats. It waits `PACKET_INTERVAL * PACKS_PER_HOP * HOP_COUNT * 1.1` at each rate. Example: 4ms * 4 * 80 * 1.1 = 1.408s for 250Hz. The duration is extended 10x if a valid packet is received during that time. Even with `LOCK_ON_FIRST_CONNECTION`, the rate can be changed by changing the TX rate using ELRS.lua while connected, or by power cycling the RX.
 
 ```
-#-DUSE_DIVERSITY
+USE_DIVERSITY
 ```
-Enable antenna-switching diversity for RX that support it.
+Enable antenna-switching diversity for RX that support it. Safe to leave on for hardware that doesn't have diversity except DIY builds which did not populate the RF switch.
 
 ```
--DDYNPOWER_THRESH_UP=15
--DDYNPOWER_THRESH_DN=21
+DYNPOWER_THRESH_UP=15
+DYNPOWER_THRESH_DN=21
 ```
 Change the RSSI thresholds used by the Dynamic Power algorithm. If the RSSI moving average is below `DYNPOWER_THRESH_UP` dBm from the sensitivity limit, the algorithm will increase the power output by one step. Similarly, if the RSSI is above `DYNPOWER_THRESH_DN` from the sensitivity limit, the power will be decreased one step.
 
 ## Compatability Options
 ```
--DUART_INVERTED
+UART_INVERTED
 ```
 This **only works** with `ESP32` based TXes (will not work with modules without built-in inversion/uninversion), but enables compatibility with radios that output inverted CRSF, such as the FrSky QX7, TBS Tango 2, RadioMaster TX16S. You want to keep this enabled in most of the cases. If your radio is T8SG V2 or you use Deviation firmware turn this setting off.
 
 ```
--DRCVR_INVERT_TX
+RCVR_INVERT_TX
 ```
-This **only works** with `ESP8266/ESP8285` based RXes. Invert the TX pin in the receiver code to allow an inverted RX pin on the flight controller to be used (usually labeled SBUS input or RXI). Inverted CRSF output. RX pin (telemetry) is unaffected. Update via_BetaflightPassthrough will not work, only via_Wifi. Note that just because this description includes the word SBUS, it doesn't mean the RX will output SBUS. It is still CRSF protocol, only inverted.
+This **only works** with `ESP8266/ESP8285` based RXes. Invert the TX pin in the receiver code to allow an inverted RX pin on the flight controller to be used (usually labeled SBUS input or RXI). Inverted CRSF output. RX pin (telemetry) is unaffected. Update via_BetaflightPassthrough will not work, only via_Wifi. Note that just because this description includes the word SBUS, it doesn't mean the RX will output SBUS. It is still CRSF protocol, only inverted, so CRSF should still be the receiver protocol selected in the flight controller software.
 
 ```
-#-DUSE_R9MM_R9MINI_SBUS
+USE_R9MM_R9MINI_SBUS
 ```
 **This does not turn on SBUS protocol** it simply changes the pin used for communication from those two side pins (A9 and A10) to use the pin labeled "SBUS" on the RX, which is inverted. This is useful for `F4 FCs` which only have an inverted receiver input UART RX. 🔼. This is only one way, so you lose the telemetry downlink to your radio as well as passthrough flashing. Enabling this turns on CRSF protocol output on the `S.BUS` 🚌 pin on your `R9MM/R9Mini`. `set serialrx_inverted = ON` may also be needed within Betaflight 🐝 for compatibility
 
 ## Network Options
 
 ```
--DAUTO_WIFI_ON_INTERVAL=30
+AUTO_WIFI_ON_INTERVAL=30
 ```
 ⚠️ Must be defined if you plan to update your RX over wifi without using a button on the RX ⚠️ This will automatically turn the wifi 📶 on for **any module** that has an `ESP8285` on it if no TX connection is established after N seconds from boot (the 30 is the time). This enables pushing firmware updates to the RX by connecting to its wifi network and visiting `http://10.0.0.1`.
 
@@ -119,15 +121,17 @@ HOME_WIFI_PASSWORD
 
 *New in version 2.0*
 
-These options set Home Network Access for your Wifi-enabled hardware. With these set, the devices will connect to your WiFi Network when you click on "(Wifi) Update" on the ExpressLRS Lua script (for some Tx Modules) or automatically after your set interval time (Receivers). Once the devices connect to your Home WiFi, the Update page can be accessed anywhere, in any device in the same network. Tx Module Wifi update page can be reached using the address http://elrs_tx.local, while receivers' update page can be reached via http://elrs_rx.local.
+These options set Home Network Access for your Wifi-enabled hardware. With these set, the devices will try connecting to your existing WiFi Network when you click on "(Wifi) Update" on the ExpressLRS Lua script (for some Tx Modules) or automatically after your set interval time. Once the devices connect to your Home WiFi, the Update page can be accessed anywhere, from any device on the same network. Tx Module Wifi update page can be reached using the address http://elrs_tx.local, while receivers' update page can be reached via http://elrs_rx.local.
+
+Wifi mode will first try to connect to the network specified before falling back and creating a new wifi network. The Home Network can also be modified from the webui.
 
 
 ## Other Options
 
 ```
-#-DJUST_BEEP_ONCE
-#-DMY_STARTUP_MELODY="<music string>|<bpm>|<semitone offset>" -or-
-#-DMY_STARTUP_MELODY="<rtttl string>"
+JUST_BEEP_ONCE
+MY_STARTUP_MELODY="<music string>|<bpm>|<semitone offset>" -or-
+MY_STARTUP_MELODY="<rtttl string>"
 ```
 For TXes like the R9M, this sets if the TX only beeps one-time **versus** playing a startup song. Currently, it is set to play the startup song 🎼 , but if you don't prefer it, uncomment this to turn it off. ✖️
  
@@ -138,7 +142,7 @@ Example BlHeli32 melodies are available on [Rox Wolfs youtube channel](https://w
 The build process also supports RTTTL-formatted ringtone strings. RTTTL melodies are delimited by colons `:` and start with a description versus the BLHeli style with have pipes `|`. e.g. `Mario:d=4,o=5,b=100:32p,16e6,16e6,16p,16e6,16p,16c6,16e6,16p,16g6,8p,16p,16g`
 
 ```
--DUSE_ESP8266_BACKPACK
+USE_ESP8266_BACKPACK
 ```
 This enables communication with the **[ESP Backpack](../../hardware/esp-backpack)** for over-the-air updates (`env:FrSky_TX_R9M_via_WiFi`) 🖥️ and debugging via WebSocket 🔍. Uncommented by default, does not need to be changed.
 

--- a/docs/software/user-defines.md
+++ b/docs/software/user-defines.md
@@ -57,9 +57,9 @@ We published [R9M Fan Mod Cover](../../hardware/fan-mod/), a custom 3d printed b
 ```
 NO_SYNC_ON_ARM
 ```
-**no sync on arm** doesn't transmit sync packets while armed. This is useful for racing as there is less time & packets wasted 🗑️ on sending sync packets. **HOWEVER** if you are doing serious long range ⛰️, keep this commented because in the case of a sustained failsafe, link can not be regained while armed.
+**no sync on arm** doesn't transmit sync packets while armed. This is useful for racing as there is less time & packets wasted 🗑️ on sending sync packets (one packet every 5 seconds if connected). **HOWEVER** if you are doing serious long range ⛰️, keep this disabled because in the case of a sustained failsafe, link can not be regained while armed.
 
-AUX1 is the channel ExpressLRS uses to detect "ARMED", and this feature assumes that a **low value of the arm switch is disarmed, and a high value is armed**. OpenTX can invert your switch if you prefer it to be mechanically inverted. It may be best not to enable no sync on arm when you are first setting up ExpressLRS as it can be a source of confusion.
+AUX1 is the channel ExpressLRS uses to detect "ARMED", and this feature assumes that a **low value of the arm switch is disarmed, and a high value is armed**. OpenTX can invert your switch if you prefer it to be mechanically inverted. It is best not to enable no sync on arm when you are first setting up ExpressLRS as it can be a source of confusion.
  
 ```
 FEATURE_OPENTX_SYNC

--- a/docs/software/user-defines.md
+++ b/docs/software/user-defines.md
@@ -94,6 +94,12 @@ Change the RSSI thresholds used by the Dynamic Power algorithm. If the RSSI movi
 -DUART_INVERTED
 ```
 This **only works** with `ESP32` based TXes (will not work with modules without built-in inversion/uninversion), but enables compatibility with radios that output inverted CRSF, such as the FrSky QX7, TBS Tango 2, RadioMaster TX16S. You want to keep this enabled in most of the cases. If your radio is T8SG V2 or you use Deviation firmware turn this setting off.
+
+```
+-DRCVR_INVERT_TX
+```
+This **only works** with `ESP8266/ESP8285` based RXes. Invert the TX pin in the receiver code to allow an inverted RX pin on the flight controller to be used (usually labeled SBUS input or RXI). Inverted CRSF output. RX pin (telemetry) is unaffected. Update via_BetaflightPassthrough will not work, only via_Wifi. Note that just because this description includes the word SBUS, it doesn't mean the RX will output SBUS. It is still CRSF protocol, only inverted.
+
 ```
 -DUSE_UART2
 ```

--- a/docs/software/user-defines.md
+++ b/docs/software/user-defines.md
@@ -101,11 +101,6 @@ This **only works** with `ESP32` based TXes (will not work with modules without 
 This **only works** with `ESP8266/ESP8285` based RXes. Invert the TX pin in the receiver code to allow an inverted RX pin on the flight controller to be used (usually labeled SBUS input or RXI). Inverted CRSF output. RX pin (telemetry) is unaffected. Update via_BetaflightPassthrough will not work, only via_Wifi. Note that just because this description includes the word SBUS, it doesn't mean the RX will output SBUS. It is still CRSF protocol, only inverted.
 
 ```
--DUSE_UART2
-```
-This enables integration with Jye's **[FENIX rx5805 pro-diversity module](https://github.com/JyeSmith/FENIX-rx5808-pro-diversity)** 👷 
-
-```
 #-DUSE_R9MM_R9MINI_SBUS
 ```
 **This does not turn on SBUS protocol** it simply changes the pin used for communication from those two side pins (A9 and A10) to use the pin labeled "SBUS" on the RX, which is inverted. This is useful for `F4 FCs` which only have an inverted receiver input UART RX. 🔼. This is only one way, so you lose the telemetry downlink to your radio as well as passthrough flashing. Enabling this turns on CRSF protocol output on the `S.BUS` 🚌 pin on your `R9MM/R9Mini`. `set serialrx_inverted = ON` may also be needed within Betaflight 🐝 for compatibility


### PR DESCRIPTION
Add documentation for the RCVR_INVERT_TX option, to use am SBUS pad on a FC. NOT SBUS PROTOCOL, inverted CRSF!!

* Moves USE_UART2 to obsolete_defines.
* Rewrites quick start's "Firmware Options" page to just contain essential settings