### PR TITLE
update ardupilot guide

### DIFF
--- a/docs/quick-start/ardupilot-setup.md
+++ b/docs/quick-start/ardupilot-setup.md
@@ -6,18 +6,20 @@ template: main.html
 
 ## Ardupilot Serial Setup
 
+Ardupilot Firmware must be 4.1 or higher to run CRSF protocol.
 As with any serial-based receiver, you need to attach the TX/RX pads to a UART on your flight controller, then enable Serial RX in the corresponding UART in Ardupilot.
 In mission planner, you will need to go to the ```config tab -> parameter tree```
 ```
-SERIALx_PROT = 23 (RCIN)
+SERIALx_PROTOCOL = 23 (RCIN)
 RSSI_TYPE = 3 (ReceiverProtocol)
+RC_OPTIONS = 9
 ```
 
 Once you have set the parameter above, power-cycle the flight controller by disconnecting and reconnecting your battery and USB. Ardupilot should automatically run with ELRS, but if it fails, set the other parameter as below:
 ```
-SERIALx_PROT = 23 (RCIN)
-SERIALx_BAUD = 115
-RC_PROT = 9 (CRSF)
+SERIALx_PROTOCOL = 23 (RCIN)
+SERIALx_BAUDRATE = 115
+RC_PROTOCOL = 9 (CRSF)
 RSSI_TYPE = 3 (ReceiverProtocol)
 ```
 
@@ -28,22 +30,12 @@ FLTMODE_CH=12
 ```
 
 ## Ardupilot RSSI and Link Quality
-To show RSSI (in %) set:
+To get RSSI and LQ shown in OSD (in %) set:
 ```
 RSSI_TYPE = 3 (ReceiverProtocol)
 ```
-But if you prefer to see the LQ instead of RSSI, you need to set:
-```
-RSSI_TYPE = 2 (RC Channel PWM value)
-RSSI_CHANNEL = 15 (channel 15 is LQ)
-```
-And if you prefer to see all Rfmode, LQ, and RSSI dBm simultaneously, you will need a custom firmware of Ardupilot that has a small snippet to show RFmode, LQ, and RSSI. You can get your Ardupilot .hex files for the custom firmware here:
-https://github.com/StonedDawg/ardupilot/tree/4.1devrssi/release
 
-Click on the FC firmware you need, and then right click on the download button and save link as. and set:
-```
-RSSI_TYPE = 3 (ReceiverProtocol)
-```
-This custom firmware will show the OSD LQ ELEMENT as XX.YYY (RFmode.LQ) and the OSD RSSI ELEMENT as dBm. It will also bypass the Ardupilot crossfire serial number check, that causes a notification message to keep popping up (CRSF: RFmode is x, rate is xx).
+and go to your OSD tab, and place your RSSI and LQ element where you want them to be.
+
 
 Happy Flying! :airplane:


### PR DESCRIPTION
as ardupilot 4.1 stable version has been released, it is now has the LQ osd element, and also the option to "mute" the crossfire version number check that keep popping up  in the OSD (RC_OPTION = 9). since the official ardupilot branch has almost covered everything necessary to fly ELRS/CRSF comfortably, I have removed the link to my branch to keep user out of a deeper confusion and updated the new parameter setup necessary to get things work on 4.1 stable release.