### PR TITLE
Add receiver hardware table

### DIFF
--- a/docs/hardware/receiver-selection.md
+++ b/docs/hardware/receiver-selection.md
@@ -1,0 +1,63 @@
+---
+template: main.html
+---
+
+![HW Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/hardware.png)
+
+ExpressLRS is hashtag blessed with the benefit of there being many receivers available from a variety of manufacturers. This begs the question "Which receiver is best?" There is no best receiver, there is only which one has the features you want for the price you want to pay in the size you want it. ExpressLRS does not recommend a specific brand or model, but provide the information to help you select the right receiver for your needs.
+
+# Team2.4
+| Model | Price | Size | LNA | PA | Antenna | WiFi | RTF |
+|---|---|---|---|---|---|---|---|
+| BetaFPV Nano 2.4 | :moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | 20dBm | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| DIY Nano 2.4 | :moneybag: | :balance_scale::balance_scale: | :x: | :x: | :whale:/:whale::whale:/:whale::whale::metal: | :heavy_check_mark: | :x: |
+| Flywoo EL24E | :moneybag: | :balance_scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
+| Flywoo EL24P | :moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| Ghost ATTO | :moneybag::moneybag::moneybag::moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :x: | :x: |
+| HappyModel PP | :moneybag::moneybag: | :balance_scale: | :x: | :x: | :whale: | :x: | :checkered_flag: |
+| HappyModel EP1 | :moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| HappyModel EP2 | :moneybag: | :balance_scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
+| HGLRC 2400RX | :moneybag::moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: | 
+| JHEMCU / HiYOUNGER EP24S | :moneybag: | :balance_scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
+| JHEMCU / HiYOUNGER SP24S | :moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| JHEMCU / HiYOUNGER RX24T | :moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | 20dBm? | :whale::whale: | :heavy_check_mark: | :checkered_flag: | 
+| Matek R24-S | :moneybag::moneybag: | :balance_scale::balance_scale::balance_scale:| :heavy_check_mark: | 20dBm | :whale: | :heavy_check_mark: | :checkered_flag: |
+| Matek R24-D | :moneybag::moneybag: | :balance_scale::balance_scale::balance_scale: | :heavy_check_mark: | 23dBm | :whale::whale::metal: | :heavy_check_mark: | :checkered_flag: |
+| Namimno Flash (ESP) | :moneybag::moneybag::moneybag: | :balance_scale::balance_scale: | :x: | :x: | :whale:/:whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| QuadKopters Nano | :moneybag::moneybag:? | :balance_scale::balance_scale: | :x: | :x: | :whale:/:whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| SIYI FR Mini | :moneybag::moneybag::moneybag: | :balance_scale::balance_scale::balance_scale: | :heavy_check_mark: | 23dBm | :whale::whale::metal: | :x: | :x: |
+
+# Team900
+| Model | Price | Size | LNA | PA | Antenna | WiFi | RTF |
+|---|---|---|---|---|---|---|---|
+| BetaFPV Nano 900 | :moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :heavy_check_mark: |
+| FrSky R9 | :moneybag::moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :x: |
+| Jumper R9 Mini | :moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :x: |
+| NamimnoRC Voyager | :moneybag::moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :heavy_check_mark: |
+
+## Most important column
+* **Whoops / Toothpicks / Light aircraft** Size is probably the most important feature, with a light small receiver and an onboard antenna being the best choice.
+* **Racing Quads** Size is again most important. Ceramic antennas could be less easily damaged, and the reduced range of tucking it inside the frame is fine due to the short flight range. An external 2.4GHz antenna dipole is still pretty easy to fit and can be tucked away for a small improvement over the ceramic, but comes with Chance of Choppage.
+* **Freestyle Quads** Minimum size is no longer an issue so Nano-sized receivers (:balance_scale::balance_scale:) are the best bet here. A LNA is going to give you better reception behind obstacles. External antennas are a benefit as well, but you need to trade off how unobstructed the antenna will be versus getting it chopped. Diversity is of marginal benefit.
+* **Long Range** For sure you need an LNA, an external antenna, and a PA to extend the telemetry range. This isn't to say these are required for long range, 5km is achievable on a ceramic antenna receiver with no LNA/PA at 250Hz/100mW with clear line of sight. Diversity is worth a lot more here. For absolute maximum range, Team900 has a clear advantage, but Team2.4 can still reach 30km+.
+
+### Price
+Probably the most important thing on this list for most people. ExpressLRS receivers are very cheap because the developers give their time for free and we pass those savings on to you! Price here instead is broken into classes: dirt cheap (:moneybag:), pretty cheap (:moneybag::moneybag:), expensive for ELRS (:moneybag::moneybag::moneybag:), and Mr Moneybags (:moneybag::moneybag::moneybag::moneybag:). These refer to the refer to the retail price, not the price you can buy the equipment used.
+
+### Size
+The FPV world shook when ELRS released receivers that were half the size of "nano" sized receivers, included the antenna onboard, and still had kilometers of range at 250Hz/100mW. A small receiver can fit in tight places, but remember that tucking a tiny receiver's ceramic antenna deep inside a stack behind carbon reduces its performance, which was already compromised by the elimination of amplifiers to make it that small. Size is broken into classes: :balance_scale: (EP2 / Ghost Zepto), :balance_scale::balance_scale: (Crossfire Nano), :balance_scale::balance_scale::balance_scale: (anything bigger). Weight is directly related to size, so there is on separate category for that. Just know that a smol receiver with an external antenna will weigh more than one with a ceramic antenna.
+
+### Low Noise Amplifier (LNA)
+A Low Noise Amplifier directly adds to your **incoming** RSSI. Typical gains are in the ballpark of +12dBm which will be observed in the RSSI as being 12dBm higher than it would have been without the LNA. This is because the LNA amplifies the incoming signal coming from the antenna before going to the RF chip, which increases the sensitivity of the receiver by boosting the incoming signal. An LNA also boosts the noise by the same amount so the sensitivity limit will likely be higher than the value quoted by the Lua.
+
+### Power Amplifier (PA)
+A Power Amplifier boosts the **outgoing** signal strength, and extends telemetry range back to the TX. Without a PA, the power output is limited by the RF chip's max power output itself (around +13dBm 20mW). It works the same way as turning up the power output on the transmitter module, however it is not adjustable. The receiver's output is always run at max power, since it runs a much lower duty cycle than the transmitter does (duty cycle = telemetry ratio). Higher numbers are better.
+
+### Antenna Type
+Antennas are where the invisible waves come and go from the receiver. Ceramic antenna < Mini Dipole ("Minimortal-T" style) < sleeved dipole < Half-wave Dipole. Don't ask how many dBm a ceramic antenna lowers your signal, it is not a flat value. Any working external antenna will outperform a ceramic, so the classes below are: Ceramic (:whale:), External (:whale::whale:), External Diversity (:whale::whale::metal:)
+
+### WiFi
+Many ExpressLRS receivers have integrated wifi with a short range. This is not active during flight, but the receiver can go into wifi mode to allow firmware updates which is pretty convenient.
+
+### Ready To Fly
+Ready To Fly (RTF) here means that it comes with ExpressLRS from the factory and you don't have to convert it from its existing software system (like Ghost or FrSky). Sometimes this can be a detriment due to needing to solder to tiny pads or buy flashing dongles.

--- a/docs/hardware/supported-hardware.md
+++ b/docs/hardware/supported-hardware.md
@@ -40,6 +40,8 @@ At the time of writing, here are the ExpressLRS-supported Transmitter Modules an
 
 ## 2.4GHz Receivers
 
+To help find the right receiver for your needs, see the [Receiver Selection](../receiver-selection/) page.
+
 ### Happymodel EP1 & EP2
 
 [Flashing Guide](../../quick-start/rx-hmep2400/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,6 +181,7 @@ nav:
         - Dynamic Transmit Power: software/dynamic-transmit-power.md
   - Hardware:
       - Supported Hardware: hardware/supported-hardware.md
+      - Receiver Selection: hardware/receiver-selection.md
       - R9M Inverter Mod: hardware/inverter-mod.md
       - R9M Fan Mod: hardware/fan-mod.md
       - Troubleshooting the X9D(+): hardware/x9d-troubleshooting.md


### PR DESCRIPTION
We get a lot of questions about which receiver is best so I put together this page "Receiver Selection" in the Hardware left menu. It looks like this (I used the wiki to get the formatting right)
https://github.com/ExpressLRS/ExpressLRS/wiki/Receiver-differences

If this gets merged I can PR for a 1.0 version too.