### PR TITLE
fix ardu rc_OPTION

### DIFF
--- a/docs/quick-start/ardupilot-setup.md
+++ b/docs/quick-start/ardupilot-setup.md
@@ -12,7 +12,10 @@ In mission planner, you will need to go to the ```config tab -> parameter tree``
 ```
 SERIALx_PROTOCOL = 23 (RCIN)
 RSSI_TYPE = 3 (ReceiverProtocol)
-RC_OPTIONS = 9
+```
+Crossfire rate's enum is different with elrs enum, Since Ardupilot doesn't have a way to differentiate ELRS from Crossfire yet, when the telemetry count differs from the reported packet rate's enum, Ardupilot will notify ("CRSF Packet rate is X, telemetry Rate is X"). Currently Ardupilot provide a way to suppress this notification with the parameter below. (this will not cause any effect to RC link or telemetry Link.)
+```
+RC_OPTIONS turn on Bit 9th which is  "Suppress CRSF mode/rate message for ELRS systems".
 ```
 
 Once you have set the parameter above, power-cycle the flight controller by disconnecting and reconnecting your battery and USB. Ardupilot should automatically run with ELRS, but if it fails, set the other parameter as below:

--- a/docs/quick-start/ardupilot-setup.md
+++ b/docs/quick-start/ardupilot-setup.md
@@ -13,7 +13,7 @@ In mission planner, you will need to go to the ```config tab -> parameter tree``
 SERIALx_PROTOCOL = 23 (RCIN)
 RSSI_TYPE = 3 (ReceiverProtocol)
 ```
-Crossfire rate's enum is different with elrs enum, Since Ardupilot doesn't have a way to differentiate ELRS from Crossfire yet, when the telemetry count differs from the reported packet rate's enum, Ardupilot will notify ("CRSF Packet rate is X, telemetry Rate is X"). Currently Ardupilot provide a way to suppress this notification with the parameter below. (this will not cause any effect to RC link or telemetry Link.)
+our packet rate is different than CRSF packet rate, and ardupilot will keep on reporting the missmatch, but recently they have an option to suppress the report. Currently Ardupilot provide a way to suppress this notification with the parameter below. (this will not cause any effect to RC link or telemetry Link.)
 ```
 RC_OPTIONS turn on Bit 9th which is  "Suppress CRSF mode/rate message for ELRS systems".
 ```


### PR DESCRIPTION
our packet rate is different than CRSF packet rate, and ardupilot will keep on reporting the missmatch, but recently they have an option to suppress the report, which I have put in the guid but I didn't write it correctly. it should not change the parameter(RC OPTION) value to 9 but instead it should turn on the parameter 9th bit. as mentioned in issue #88 .