### PR TITLE
Adds Supported Version info for the Siyi FR Mini

### DIFF
--- a/docs/hardware/supported-hardware.md
+++ b/docs/hardware/supported-hardware.md
@@ -78,6 +78,8 @@ At the time of writing, here are the ExpressLRS-supported Transmitter Modules an
 
 [Flashing Guide](../../quick-start/rx-siyiFRmini/)
 
+*Note: only guaranteed to work on the v3.0 of the receiver*
+
 ## 900Mhz Transmitter Modules
 
 ### Frsky R9M (inc. Lite & Lite Pro)

--- a/docs/quick-start/rx-siyiFRmini.md
+++ b/docs/quick-start/rx-siyiFRmini.md
@@ -9,6 +9,8 @@ Targets:
 - `FM30_RX_MINI_via_STLINK` (First-time Flash)
 - `FM30_RX_MINI_via_BetaflightPassthrough` (Updates)
 
+**Note: only guaranteed to work on the v3.0 of the receiver.**
+
 The STLink solderpads on the FRmini RX are very tiny and very close together. The picture below is very enlarged.
 Solder 5  (preferable Silicon) wires to the GND-RST-VDD-CLK-DIO pads. Solder the open ends to a female 2.54 mm pin connector. (Use 3.3V NOT 5V :fire:).
 


### PR DESCRIPTION
Adds a note that Siyi FR Mini v3.0 is the version that's supported. v4.0, that just came out has a different MCU and thus will not work.