### PR TITLE
Replace balance_scale with scale emoji

### DIFF
--- a/docs/hardware/receiver-selection.md
+++ b/docs/hardware/receiver-selection.md
@@ -9,43 +9,44 @@ ExpressLRS is hashtag blessed with the benefit of there being many receivers ava
 # Team2.4
 | Model | Price | Size | LNA | PA | Antenna | WiFi | RTF |
 |---|---|---|---|---|---|---|---|
-| BetaFPV Nano 2.4 | :moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | 20dBm | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
-| DIY Nano 2.4 | :moneybag: | :balance_scale::balance_scale: | :x: | :x: | :whale:/:whale::whale:/:whale::whale::metal: | :heavy_check_mark: | :x: |
-| Flywoo EL24E | :moneybag: | :balance_scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
-| Flywoo EL24P | :moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
-| Ghost ATTO | :moneybag::moneybag::moneybag::moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :x: | :x: |
-| HappyModel PP | :moneybag::moneybag: | :balance_scale: | :x: | :x: | :whale: | :x: | :checkered_flag: |
-| HappyModel EP1 | :moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
-| HappyModel EP2 | :moneybag: | :balance_scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
-| HGLRC 2400RX | :moneybag::moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: | 
-| JHEMCU / HiYOUNGER EP24S | :moneybag: | :balance_scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
-| JHEMCU / HiYOUNGER SP24S | :moneybag: | :balance_scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
-| JHEMCU / HiYOUNGER RX24T | :moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | 20dBm? | :whale::whale: | :heavy_check_mark: | :checkered_flag: | 
-| Matek R24-S | :moneybag::moneybag: | :balance_scale::balance_scale::balance_scale:| :heavy_check_mark: | 20dBm | :whale: | :heavy_check_mark: | :checkered_flag: |
-| Matek R24-D | :moneybag::moneybag: | :balance_scale::balance_scale::balance_scale: | :heavy_check_mark: | 23dBm | :whale::whale::metal: | :heavy_check_mark: | :checkered_flag: |
-| Namimno Flash (ESP) | :moneybag::moneybag::moneybag: | :balance_scale::balance_scale: | :x: | :x: | :whale:/:whale::whale: | :heavy_check_mark: | :checkered_flag: |
-| QuadKopters Nano | :moneybag::moneybag:? | :balance_scale::balance_scale: | :x: | :x: | :whale:/:whale::whale: | :heavy_check_mark: | :checkered_flag: |
-| SIYI FR Mini | :moneybag::moneybag::moneybag: | :balance_scale::balance_scale::balance_scale: | :heavy_check_mark: | 23dBm | :whale::whale::metal: | :x: | :x: |
+| BetaFPV Nano 2.4 | :moneybag::moneybag: | :scale::scale: | :heavy_check_mark: | 20dBm | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| DIY Nano 2.4 | :moneybag: | :scale::scale: | :x: | :x: | :whale:/:whale::whale:/:whale::whale::metal: | :heavy_check_mark: | :x: |
+| Flywoo EL24E | :moneybag: | :scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
+| Flywoo EL24P | :moneybag: | :scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| Ghost ATTO | :moneybag::moneybag::moneybag::moneybag: | :scale: | :x: | :x: | :whale::whale: | :x: | :x: |
+| HappyModel PP | :moneybag::moneybag: | :scale: | :x: | :x: | :whale: | :x: | :checkered_flag: |
+| HappyModel EP1 | :moneybag: | :scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| HappyModel EP2 | :moneybag: | :scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
+| HGLRC 2400RX | :moneybag::moneybag: | :scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: | 
+| JHEMCU / HiYOUNGER EP24S | :moneybag: | :scale: | :x: | :x: | :whale: | :heavy_check_mark: | :checkered_flag: |
+| JHEMCU / HiYOUNGER SP24S | :moneybag: | :scale: | :x: | :x: | :whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| JHEMCU / HiYOUNGER RX24T | :moneybag::moneybag: | :scale::scale: | :heavy_check_mark: | 20dBm? | :whale::whale: | :heavy_check_mark: | :checkered_flag: | 
+| Matek R24-S | :moneybag::moneybag: | :scale::scale::scale:| :heavy_check_mark: | 20dBm | :whale: | :heavy_check_mark: | :checkered_flag: |
+| Matek R24-D | :moneybag::moneybag: | :scale::scale::scale: | :heavy_check_mark: | 23dBm | :whale::whale::metal: | :heavy_check_mark: | :checkered_flag: |
+| Namimno Flash (ESP) | :moneybag::moneybag::moneybag: | :scale::scale: | :x: | :x: | :whale:/:whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| QuadKopters Nano | :moneybag::moneybag:? | :scale::scale: | :x: | :x: | :whale:/:whale::whale: | :heavy_check_mark: | :checkered_flag: |
+| SIYI FR Mini | :moneybag::moneybag::moneybag: | :scale::scale::scale: | :heavy_check_mark: | 23dBm | :whale::whale::metal: | :x: | :x: |
 
 # Team900
 | Model | Price | Size | LNA | PA | Antenna | WiFi | RTF |
 |---|---|---|---|---|---|---|---|
-| BetaFPV Nano 900 | :moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :heavy_check_mark: |
-| FrSky R9 | :moneybag::moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :x: |
-| Jumper R9 Mini | :moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :x: |
-| NamimnoRC Voyager | :moneybag::moneybag::moneybag: | :balance_scale::balance_scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :heavy_check_mark: |
+| BetaFPV Nano 900 | :moneybag::moneybag: | :scale::scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :heavy_check_mark: |
+| FrSky R9 | :moneybag::moneybag::moneybag: | :scale::scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :x: |
+| HappyModel ES900RX | :moneybag::moneybag: | :scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :heavy_check_mark: | :heavy_check_mark: |
+| Jumper R9 Mini | :moneybag::moneybag: | :scale::scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :x: |
+| NamimnoRC Voyager | :moneybag::moneybag::moneybag: | :scale::scale: | :heavy_check_mark: | :heavy_check_mark: | :whale::whale: | :x: | :heavy_check_mark: |
 
 ## Most important column
 * **Whoops / Toothpicks / Light aircraft** Size is probably the most important feature, with a light small receiver and an onboard antenna being the best choice.
 * **Racing Quads** Size is again most important. Ceramic antennas could be less easily damaged, and the reduced range of tucking it inside the frame is fine due to the short flight range. An external 2.4GHz antenna dipole is still pretty easy to fit and can be tucked away for a small improvement over the ceramic, but comes with Chance of Choppage.
-* **Freestyle Quads** Minimum size is no longer an issue so Nano-sized receivers (:balance_scale::balance_scale:) are the best bet here. A LNA is going to give you better reception behind obstacles. External antennas are a benefit as well, but you need to trade off how unobstructed the antenna will be versus getting it chopped. Diversity is of marginal benefit.
+* **Freestyle Quads** Minimum size is no longer an issue so Nano-sized receivers (:scale::scale:) are the best bet here. A LNA is going to give you better reception behind obstacles. External antennas are a benefit as well, but you need to trade off how unobstructed the antenna will be versus getting it chopped. Diversity is of marginal benefit.
 * **Long Range** For sure you need an LNA, an external antenna, and a PA to extend the telemetry range. This isn't to say these are required for long range, 5km is achievable on a ceramic antenna receiver with no LNA/PA at 250Hz/100mW with clear line of sight. Diversity is worth a lot more here. For absolute maximum range, Team900 has a clear advantage, but Team2.4 can still reach 30km+.
 
 ### Price
 Probably the most important thing on this list for most people. ExpressLRS receivers are very cheap because the developers give their time for free and we pass those savings on to you! Price here instead is broken into classes: dirt cheap (:moneybag:), pretty cheap (:moneybag::moneybag:), expensive for ELRS (:moneybag::moneybag::moneybag:), and Mr Moneybags (:moneybag::moneybag::moneybag::moneybag:). These refer to the refer to the retail price, not the price you can buy the equipment used.
 
 ### Size
-The FPV world shook when ELRS released receivers that were half the size of "nano" sized receivers, included the antenna onboard, and still had kilometers of range at 250Hz/100mW. A small receiver can fit in tight places, but remember that tucking a tiny receiver's ceramic antenna deep inside a stack behind carbon reduces its performance, which was already compromised by the elimination of amplifiers to make it that small. Size is broken into classes: :balance_scale: (EP2 / Ghost Zepto), :balance_scale::balance_scale: (Crossfire Nano), :balance_scale::balance_scale::balance_scale: (anything bigger). Weight is directly related to size, so there is on separate category for that. Just know that a smol receiver with an external antenna will weigh more than one with a ceramic antenna.
+The FPV world shook when ELRS released receivers that were half the size of "nano" sized receivers, included the antenna onboard, and still had kilometers of range at 250Hz/100mW. A small receiver can fit in tight places, but remember that tucking a tiny receiver's ceramic antenna deep inside a stack behind carbon reduces its performance, which was already compromised by the elimination of amplifiers to make it that small. Size is broken into classes: :scale: (EP2 / Ghost Zepto), :scale::scale: (Crossfire Nano), :scale::scale::scale: (anything bigger). Weight is directly related to size, so there is on separate category for that. Just know that a smol receiver with an external antenna will weigh more than one with a ceramic antenna.
 
 ### Low Noise Amplifier (LNA)
 A Low Noise Amplifier directly adds to your **incoming** RSSI. Typical gains are in the ballpark of +12dBm which will be observed in the RSSI as being 12dBm higher than it would have been without the LNA. This is because the LNA amplifies the incoming signal coming from the antenna before going to the RF chip, which increases the sensitivity of the receiver by boosting the incoming signal. An LNA also boosts the noise by the same amount so the sensitivity limit will likely be higher than the value quoted by the Lua.


### PR DESCRIPTION
This fixes the ⚖️ from showing up as `:balance_scale:` on the "Receiver Selection" page. The Docs site uses `:scale:` instead.

EOL was also changed to LF to be consistent with other docs I think?