### PR TITLE
removed mass_erase

### DIFF
--- a/docs/software/open-ocd.md
+++ b/docs/software/open-ocd.md
@@ -11,7 +11,7 @@ If you are using Linux then you can't use the ST-LINK utility from st.com. But f
 
     a. For R9mm/Mini `openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c 'init; reset halt; stm32f1x unlock 0; reset run; shutdown'`
 
-    b. For Ghost Átto/Zepto `openocd -f interface/stlink-v2.cfg -f target/stm32f3x.cfg -c 'init; reset halt; stm32f3x unlock 0; flash protect 0 0 last off; stm32f3x mass_erase 0; reset halt; exit'`
+    b. For Ghost Átto/Zepto `openocd -f interface/stlink-v2.cfg -f target/stm32f3x.cfg -c 'init; reset halt; stm32f3x unlock 0; flash protect 0 0 last off; reset halt; exit'`
 
 3. Restart your device so the disabled readout protection can take effect.
 4. Now you can proceed with flashing your receiver. This may work on other devices or it might not.


### PR DESCRIPTION
The "stm32f3x mass_erase 0" is not really necessary. The flash gets wiped anyway when the read protection is removed.