### PR TITLE
Webpage bullet messed up

### DIFF
--- a/docs/software/dynamic-transmit-power.md
+++ b/docs/software/dynamic-transmit-power.md
@@ -20,6 +20,7 @@ Note: These videos were taken with a test version. The power lowering/raising th
 ### How to configure Dynamic Power
 
 On the ELRS Lua script v2, Select `> TX Power`. There are three configurable elements.
+
 * `Max Power`: The output power will never exceed this power output level in any situation.
 * `Dynamic`: Three options are available.
   - `Off`: Fixed power, always set to the configure `Max Power` output.


### PR DESCRIPTION
I found the web page has messed with the bullet list on the "How to configure Dynamic Power" section.
https://www.expresslrs.org/2.0/software/dynamic-transmit-power/

Probably adding a blank line resolves the issue.