### PR TITLE
[Footer] - Add condition for next page

### DIFF
--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -1,0 +1,57 @@
+<footer class="md-footer">
+  {% if page.previous_page or page.next_page %}
+    <nav class="md-footer__inner md-grid" aria-label="{{ lang.t('footer.title') }}">
+    {% if page.previous_page %}
+      {% set direction = lang.t("footer.previous") %}
+      <a href="{{ page.previous_page.url | url }}" class="md-footer__link md-footer__link--prev" aria-label="{{ direction }}: {{ page.previous_page.title | e }}" rel="prev">
+      <div class="md-footer__button md-icon">
+        {% include ".icons/material/arrow-left.svg" %}
+      </div>
+      <div class="md-footer__title">
+        <div class="md-ellipsis">
+        <span class="md-footer__direction">
+          {{ direction }}
+        </span>
+        {{ page.previous_page.title }}
+        </div>
+      </div>
+      </a>
+    {% endif %}
+    {% if page.next_page %}
+      {% set direction = lang.t("footer.next") %}
+      <!-- Use of variable for next URL and next page title in order to switch them when needed -->
+      {% if page.parent.title == "Flashing TX Modules" %}
+        {% set next_page_url = "quick-start/lua-howto" %}
+        {% set next_page_title = "Using The Lua Script" %}
+        <a href="{{ next_page_url | url }}" class="md-footer__link md-footer__link--next" aria-label="{{ direction }}: {{ next_page_title | e }}" rel="next">
+      {% elif page.parent.title == "Flashing Receivers" %}
+        {% set next_page_url = "quick-start/led-status" %}
+        {% set next_page_title = "LED Status" %}
+        <a href="{{ next_page_url | url }}" class="md-footer__link md-footer__link--next" aria-label="{{ direction }}: {{ next_page_title | e }}" rel="next">
+      {% else %}
+        {% set next_page_title = page.next_page.title %}
+        <a href="{{ page.next_page.url | url }}" class="md-footer__link md-footer__link--next" aria-label="{{ direction }}: {{ page.next_page.title | e }}" rel="next">
+      {% endif %}
+      <div class="md-footer__title">
+        <div class="md-ellipsis">
+        <span class="md-footer__direction">
+          {{ direction }}
+        </span>
+        {{ next_page_title }}
+        </div>
+      </div>
+      <div class="md-footer__button md-icon">
+        {% include ".icons/material/arrow-right.svg" %}
+      </div>
+      </a>
+    {% endif %}
+    </nav>
+  {% endif %}
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+    {% if config.extra.social %}
+      {% include "partials/social.html" %}
+    {% endif %}
+    </div>
+  </div>
+</footer>


### PR DESCRIPTION
Hi,
It's my first PR for this project and I hope it will be able to help the project.
Yesterday I saw this [conversation](https://discord.com/channels/596350022191415318/738450139693449258/921986928444837908) about the Next button on the footer of the `Flashing TX Modules` and `Flashing Receivers` subpages.

### Current behaviour
When on a subpage of `Flashing TX Modules` or `Flashing Receivers`, it does not make sense to click "Next" and go to the next module or receiver since we expect to go to the next step of the process

### Proposed behaviour
When on one of those subpages, the Next button will go to the next logical step of the process.

### Detail of the workaround
Created a footer override in `overrides/partials/footer.html` as mentioned in the [MkDocs](https://www.mkdocs.org/dev-guide/themes/?)
The real stuff happen between l.22 and l.33, the rest is the footer base template from [Mkdocs/Material](https://github.com/squidfunk/mkdocs-material/blob/master/material/partials/footer.html)
It will check if we are in one of these two sections (Flashing TX Modules or Flashing Receivers) and will override the next page to be the _good_ one (instead of going through all the other modules / receivers, which does not make sense for "what to do _next_")

It's not perfect since the URLs and title are hard encoded in the template, so, for translation it will need few changes.

Hope it will help,
Adrien.