### PR TITLE
Update Namimno OLED USB Drivers

### DIFF
--- a/docs/quick-start/transmitters/tx-flash2400.md
+++ b/docs/quick-start/transmitters/tx-flash2400.md
@@ -67,7 +67,7 @@ Verify the version and hash in the main screen of ExpressLRS Lua script.
 
 Target: `NamimnoRC_FLASH_2400_OLED_TX_via_UART`
 
-Attach your USB cable into the module and your computer. [CP210x Drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers) will have to be installed for this to work properly (Windows). Make sure your computer recognizes the module as a USB-to-UART Bridge device, otherwise, this method will not work.
+Attach your USB cable into the module and your computer. [CH340 Drivers](https://sparks.gogo.co.nz/assets/_site_/downloads/CH34x_Install_Windows_v3_4.zip) will have to be downloaded (Right-click, Save-as) and installed (Unzip the contents of the file; Run the executable installer) for this to work properly (Windows). Make sure your computer recognizes the module as a USB-SERIAL CH340 device, otherwise, this method will not work. 
 
 Using the ExpressLRS Configurator with the correct Target selected and [Firmware Options] set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
 

--- a/docs/quick-start/transmitters/tx-voyager900.md
+++ b/docs/quick-start/transmitters/tx-voyager900.md
@@ -4,78 +4,7 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
-## 2nd Gen, OLED-equipped
-
-These newer devices are now using an ESP-based MCU compared to the first version. With this in mind, the Flashing method will differ slightly, and should now be the same as with other ESP-based Tx Modules.
-
-### Flashing via WiFi
-
-Target: `NamimnoRC_VOYAGER_900_OLED_TX_via_WIFI`
-
-#### Method 1
-
-With the correct target selected and [Firmware Options] set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `NamimnoRC_VOYAGER_900_OLED_TX-<version>.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
-
-The next steps will require the [ExpressRLS Lua Script](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/elrsV2.lua?raw=true) (right-click, save as). Download the ExpressLRS lua script and save it to your Radio's `/Scripts/Tools` folder. Insert/attach your module into your module bay and make sure it's not loose and there's proper connection with the radio (see the [Radio Preparation] page). Execute the ExpressLRS lua script by pressing "System Menu" in your radio and then under Tools, select `ExpressLRS`.
-
-![Lua Script](../../assets/images/lua1.jpg)
-![Lua Script T16](../../assets/images/lua2.jpg)
-
-If the script is stuck at `Loading...`, then there's a chance your module is still in v1.x firmware, your External RF module is not set to CRSF or that your module is not well-connected to the module bay pins.
-
-![Lua3](../../assets/images/lua3.jpg)
-
-Select **WiFi Connectivity** from the Lua script and then select **Enable WiFi**. Press OK once more to activate the WiFi on the Tx Module. Connect to the Access Point the module will create called `ExpressLRS TX Module`, with the password being `expresslrs`.
-
-Using your browser, navigate to the correct page (typically http://10.0.0.1/) and it should show an upload form (you will have to scroll down a bit). You can drag-and-drop the `NamimnoRC_VOYAGER_900_OLED_TX-<version>.bin` file that the ExpressLRS Configurator created. You can also click the `Choose File` button and navigate to the folder where the firmware was created. Ensure that you have selected the correct firmware file and click `Update`.
-
-Once the file is uploaded, a pop-up confirmation will show up. Wait for the Lua script screen to close the "WiFi Running" screen and your module should be updated now.
-
-Verify the version and hash in the main screen of ExpressLRS Lua script.
-
-**Update for version 2.0**
-
-Once you have updated to firmware version 2.0 or newer, the Web Update page on the Hotspot will get a few updates of its own. It will get the Update progress bar, and a Popup will be shown for Success or Error messages. Additionally, you can configure Home Network SSID and Password if you chose not to use ExpressLRS Configurator to set them. Once these are set, you can use the two methods below.
-
-![JoinNetwork](../../assets/images/web-joinnetwork.png)
-
-#### Method 2
-
-With the correct target selected and [Firmware Options] set, **Build** your firmware using the ExpressLRS Configurator. Once it's done, it should open the Target folder for you where the `NamimnoRC_VOYAGER_900_OLED_TX-<version>.bin` file is. Do not close this window so you can easily locate the correct file to upload to the module.
-
-Using the [ExpressLRS Lua Script](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/elrsV2.lua?raw=true) (right-click, save as), select `Wifi Connectivity` then choose `Enable WiFi` and if you have flashed your Tx Module with your Home WiFi Network details or have set it in Join Network section of the Update Page, it will connect to the local network automatically.
-
-Using your browser, navigate to http://elrs_tx.local and the WiFi Update page should show up. Scroll down towards the Firmware Update section, as shown below:
-
-![Firmware Update](../../assets/images/web-firmwareupdate.png)
-
-Drag-and-drop the `NamimnoRC_VOYAGER_900_OLED_TX-<version>.bin` file created by the ExpressLRS Configurator into the Choose File field, or manually navigate to the Folder by clicking the `Choose File` button. Once the correct file is selected, click the `Update`. Wait for the process to complete, and the module will reboot (~1min).
-
-Verify the version and hash in the main screen of ExpressLRS Lua script.
-
-#### Method 3
-
-Using the [ExpressLRS Lua Script](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/lua/elrsV2.lua?raw=true) (right-click, save as), select `Wifi Connectivity` then choose `Enable WiFi` and if you have flashed your Tx Module with your Home WiFi Network details or have set it in Join Network section of the Update Page, it will connect to the network automatically.
-
-Using the ExpressLRS Configurator, select the correct Target and set your [Firmware Options]. Click **Build and Flash** and wait for the compile process to complete. You should see a section as pictured below and the Success message marking the update process complete.
-
-![Wifi Update Log](../../assets/images/WifiUpdateLog.png)
-
-Verify the version and hash in the main screen of ExpressLRS Lua script.
-
-### Flashing via USB/UART
-
-Target: `NamimnoRC_VOYAGER_900_OLED_TX_via_UART`
-
-Attach your USB cable into the module and your computer. [CP210x Drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers) will have to be installed for this to work properly (Windows). Make sure your computer recognizes the module as a USB-to-UART Bridge device, otherwise, this method will not work.
-
-Using the ExpressLRS Configurator with the correct Target selected and [Firmware Options] set, hit **Build & Flash**. Wait for the process to finish, and you should be greeted with the "Success" message.
-
-Verification can be done using the [ExpressLRS lua] script. It should show the Version Number and Hash at the bottom, as well as the options you can set. If it's showing "Loading" at the top, check if External Module is set to CRSF for the selected model in your radio, and that internal RF module is set to off. See [General Troubleshooting] section for other ways to determine your module is flashed and ready for flying.
-
-## First Gen, No OLED Screen
-
-### Flashing via Wifi
+## Flashing via Wifi
 
 Target: `NamimnoRC_Voyager_900_TX_via_WiFi`
 
@@ -113,7 +42,7 @@ Using the ExpressLRS Configurator, select the correct Target and set your [Firmw
 
 Using the [ExpressLRS lua] script, verify that you have the latest version.
 
-### Flashing via OpenTX Radio
+## Flashing via OpenTX Radio
 
 *Note: The `NamimnoRC_Voyager_900_TX_via_WiFi` Target will work for this method too!*
 
@@ -125,7 +54,7 @@ Once copied, navigate to the `/FIRMWARE` Folder on your Radio and select/highlig
 
 Using the [ExpressLRS lua] script, verify that you have the latest version.
 
-### Flashing via STLink
+## Flashing via STLink
 
 Target: `NamimnoRC_Voyager_900_TX_via_STLINK`
 


### PR DESCRIPTION
Namimno OLED isn't using a CP210x for its USB.

This PR updates to link to the correct drivers and updates the instructions a bit.