### PR TITLE
Fix DP docs error / bring fan thresh up to date with master

### DIFF
--- a/docs/quick-start/transmitters/lua-howto.md
+++ b/docs/quick-start/transmitters/lua-howto.md
@@ -90,7 +90,7 @@ TX Power is a folder, press ENTER to enter the TX Power settings and use RTN/EXI
 
 * `Dynamic` enables the Dynamic Power feature. `Off` means that the TX will transmit at Max Power at all times. `On` means the TX will dynamically _lower_ power to save energy when maximum power is not needed. The options `AUX9, AUX10, AUX11, AUX12` indicate that the TX can be changed from max power to dynamic power by changing the position of a switch. where switch HIGH (>1500us) = dynamic power, switch LOW (<1500us) = max power. For more information, [Dynamic Transmit Power](../../software/dynamic-transmit-power.md) provides a deeper dive on the algorithm and usage.
 
-* `Fan Thresh` sets the power level the Fan in your module should activate. Note that not all modules have a Fan header that benefits from the setting. If this is set to 100mW, then the fan should spin up if you set `Max Power` to 100mW with `Dynamic` set to OFF. Default fan threshold is 250mW.
+* `Fan Thresh` sets the power level the Fan should activate, e.g. if set to 100mW, then the fan should spin up if you set `Max Power` to 100mW with `Dynamic` set to OFF after a short delay. The fan will continue running for some time even after the power level goes below the threshold. Not all modules have a Fan header that benefits from the setting. . Default fan threshold is 250mW.
 
 ### VTX Administrator
 

--- a/docs/software/dynamic-transmit-power.md
+++ b/docs/software/dynamic-transmit-power.md
@@ -26,7 +26,7 @@ On the ELRS Lua script v2, Select `> TX Power`. There are three configurable ele
   - `Off`: Fixed power, always set to the configure `Max Power` output.
   - `On`: Dynamic power is enabled, following the logic described below.
   - `AUX9`-`AUX12`: Dynamic power is enabled only when this AUX channel is `high`, and power is fixed to the `Max Power` when `low`.
-* `Fan Thresh`: Fan threshold. If a module has a fan, it will blow air from the power level configured here.
+* `Fan Thresh`: Fan threshold. If the module has a fan, it will be enabled starting at this power level after a short delay.
 
 Another important setting is to make sure your craft is **armed** on AUX1=`high` (~2000us). ELRS never knows the craft arming state. Instead it monitors the value of `AUX1` for arming detection. See [Switch Modes](switch-config.md) for more information about AUX channels.
 

--- a/docs/software/dynamic-transmit-power.md
+++ b/docs/software/dynamic-transmit-power.md
@@ -25,7 +25,7 @@ On the ELRS Lua script v2, Select `> TX Power`. There are three configurable ele
 * `Dynamic`: Three options are available.
   - `Off`: Fixed power, always set to the configure `Max Power` output.
   - `On`: Dynamic power is enabled, following the logic described below.
-  - `AUX9`-`AUX12`: Dynamic power is *disabled* and fixed to the `Max Power` when `high` value is assigned to this aux channel.
+  - `AUX9`-`AUX12`: Dynamic power is enabled only when this AUX channel is `high`, and power is fixed to the `Max Power` when `low`.
 * `Fan Thresh`: Fan threshold. If a module has a fan, it will blow air from the power level configured here.
 
 Another important setting is to make sure your craft is **armed** on AUX1=`high` (~2000us). ELRS never knows the craft arming state. Instead it monitors the value of `AUX1` for arming detection. See [Switch Modes](switch-config.md) for more information about AUX channels.

--- a/docs/software/user-defines.md
+++ b/docs/software/user-defines.md
@@ -90,6 +90,11 @@ DYNPOWER_THRESH_DN=21
 ```
 Change the RSSI thresholds used by the Dynamic Power algorithm. If the RSSI moving average is below `DYNPOWER_THRESH_UP` dBm from the sensitivity limit, the algorithm will increase the power output by one step. Similarly, if the RSSI is above `DYNPOWER_THRESH_DN` from the sensitivity limit, the power will be decreased one step.
 
+```
+FAN_MIN_RUNTIME=30
+```
+For TX devices with fans, FAN_MIN_RUNTIME keeps the fan running even after the power level has dropped below the configured Fan Threshold. This prevents the fan from turning on and off every few seconds if the power level is constantly changing. Default is 30 seconds if not defined, value can be 0-254. There is always a short delay before the fan is activated, which can not be disabled. 
+
 ## Compatability Options
 ```
 UART_INVERTED


### PR DESCRIPTION
There's an error in the Dynamic Power docs that says that the AUX switch must be HIGH to disable DP, but the switch enables DP.
https://www.facebook.com/groups/636441730280366/permalink/902931943631342/

This fixes that, as well as adds the info about the short delay in fan turning on, and the user_define for it turning off that is in master. I dunno how our 2.1 release is going to go, but I think we're just taking everything from master to 2.1 so this will be relevant? Everything is always a mess!