### PR TITLE
Regulatory Domain Options updated

### DIFF
--- a/docs/quick-start/firmware-options.md
+++ b/docs/quick-start/firmware-options.md
@@ -17,15 +17,18 @@ Some of these options are present on both the Tx and Rx Targets. It is important
 </figure>
 
 ## Regulatory Domains
-!!! note "Only available for 900MHz devices"
-    This option is now set automatically for 2.4GHz devices.
 ```
 Regulatory_Domain_AU_915
 Regulatory_Domain_EU_868
+Regulatory_Domain_IN_866
 Regulatory_Domain_FCC_915
-```
-This is a relatively simple one - enable whatever regulatory domain you are in to select the frequency range to be used. `EU 868` is compliant to the frequency but **is not** LBT compliant 👂.
 
+Regulatory_Domain_ISM_2400
+Regulatory_Domain_EU_CE_2400
+```
+This is a relatively simple one - enable whatever regulatory domain you are in to select the frequency range to be used.
+
+EU Regulatory domains are now LBT compliant!
 
 ## Binding Phrase
 
@@ -89,11 +92,6 @@ Sync packets are one packet out of every 5 seconds when armed. Leave this off un
 LOCK_ON_FIRST_CONNECTION
 ```
 Keeps the receiver on the last packet rate it was on if it failsafes, instead of trying every packet rate to reconnect. Should be left on.
-
-```
-USE_DIVERSITY
-```
-Enable diversity for Receivers that support it, but safe to leave on for hardware that doesn't have diversity.
 
 ## Full List
 


### PR DESCRIPTION
Added IN_866

Added back 2.4GHz Regulatory Domains.

Added info EU Reg Domains are LBT compliant.

Also removed USE_DIVERSITY option