### PR TITLE
Passthrough Method Reminder

### DIFF
--- a/docs/quick-start/receivers/axis-thor.md
+++ b/docs/quick-start/receivers/axis-thor.md
@@ -125,6 +125,8 @@ Device : `AXIS THOR 2400RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/axis-thor.md
+++ b/docs/quick-start/receivers/axis-thor.md
@@ -125,7 +125,7 @@ Device : `AXIS THOR 2400RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/betafpv2400.md
+++ b/docs/quick-start/receivers/betafpv2400.md
@@ -131,6 +131,8 @@ Device: `BETAFPV Nano 2400 RX`, `BETAFPV Lite 2400 RX` (Tower & Flattie)
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/betafpv2400.md
+++ b/docs/quick-start/receivers/betafpv2400.md
@@ -131,7 +131,7 @@ Device: `BETAFPV Nano 2400 RX`, `BETAFPV Lite 2400 RX` (Tower & Flattie)
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/betafpv900.md
+++ b/docs/quick-start/receivers/betafpv900.md
@@ -125,7 +125,7 @@ Device: `BETAFPV 900 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/betafpv900.md
+++ b/docs/quick-start/receivers/betafpv900.md
@@ -125,6 +125,8 @@ Device: `BETAFPV 900 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/configuring-fc.md
+++ b/docs/quick-start/receivers/configuring-fc.md
@@ -34,4 +34,7 @@ The CRSF Protocol requires a full UART pair, uninverted and in full-duplex mode.
 - `serialrx_halfduplex` should be **OFF**; configure it with `set serialrx_halfduplex = off`.
 - Don't forget to use `save` once you're done setting these up.
 
+!!! important
+    Close your Flight Controller Configurator once you've set it up for ExpressLRS. Keeping it open could prevent the next steps from completing properly, particularly flashing via Passthrough. You would also want to unplug the FC from USB before proceeding to the next steps.
+
 **Use the Navigation Menu to proceed to the Flashing Guides (under the section `Flashing Receivers`).**

--- a/docs/quick-start/receivers/configuring-fc.md
+++ b/docs/quick-start/receivers/configuring-fc.md
@@ -35,6 +35,6 @@ The CRSF Protocol requires a full UART pair, uninverted and in full-duplex mode.
 - Don't forget to use `save` once you're done setting these up.
 
 !!! important
-    Close your Flight Controller Configurator once you've set it up for ExpressLRS. Keeping it open could prevent the next steps from completing properly, particularly flashing via Passthrough. You would also want to unplug the FC from USB before proceeding to the next steps.
+    Close your Flight Controller Configurator once you've set it up for ExpressLRS. Keeping it open could prevent the next steps from completing properly, particularly flashing via Passthrough. You must also unplug the FC from USB before proceeding to the next steps to refresh the connection.
 
 **Use the Navigation Menu to proceed to the Flashing Guides (under the section `Flashing Receivers`).**

--- a/docs/quick-start/receivers/flash2400.md
+++ b/docs/quick-start/receivers/flash2400.md
@@ -89,7 +89,7 @@ Wait for this process to finish. It's done once the "Success" prompt is shown.
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [Wiring Guide] shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 

--- a/docs/quick-start/receivers/flash2400.md
+++ b/docs/quick-start/receivers/flash2400.md
@@ -73,6 +73,8 @@ Device :
 
 ![via Passthrough](../../assets/images/Method_RX_Passthrough.png)
 
+### STM-based receivers
+
 Once [wired properly] to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
 
 If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options] set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `PASSTHROUGH INIT` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
@@ -81,9 +83,26 @@ If your receiver didn't get powered from USB, have a lipo ready and continue wit
 
 Once `Retry... ` lines appear, connect a LiPo if your receiver isn't powered by the USB (i.e. power up your receiver and FC). On subsequent flash, you can have the LiPo plugged in and receiver powered up from the start.
 
-For the ESP-based receivers, you can connect a LiPo during the `PASSTHROUGH DONE` section of the Log.
-
 Wait for this process to finish. It's done once the "Success" prompt is shown.
+
+### ESP-based receivers
+
+Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
+
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
+You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [Wiring Guide] shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
+
+!!! attention ""
+    Note: if you powered the receiver and has solid LED light, your FC is probably pulling the current UART's RX pad `LOW` which will interfere with the normal and passthrough flashing of this receiver. Find another UART and wire your receiver there instead.
+
+These procedures will not be needed in subsequent passthrough flashing. This is only needed on the first time you'd update the receiver from its factory firmware.
+
+Select the corresponding target in the ExpressLRS Configurator, set your [Firmware Options] and then click **Build and Flash**. For first time flashing/updating, it would normally take a while.
+
+![Build & Flash](../../assets/images/BuildFlash.png)
+
+A `Success` message will be shown once the process is complete.
 
 ## Wifi Updating (ESP Only - Recommended)
 
@@ -209,3 +228,4 @@ Select the target and set your [Firmware Options] and once done, click on **Buil
 
 [Firmware Options]: ../firmware-options.md
 [wired properly]: #wiring-up-your-receiver
+[Wiring Guide]: #wiring-up-your-receiver

--- a/docs/quick-start/receivers/geprc2400.md
+++ b/docs/quick-start/receivers/geprc2400.md
@@ -131,6 +131,8 @@ Device: `GEPRC Nano 2.4GHz`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/geprc2400.md
+++ b/docs/quick-start/receivers/geprc2400.md
@@ -131,7 +131,7 @@ Device: `GEPRC Nano 2.4GHz`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/geprc900.md
+++ b/docs/quick-start/receivers/geprc900.md
@@ -126,7 +126,7 @@ Device: `GEPRC Nano 900MHz`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/geprc900.md
+++ b/docs/quick-start/receivers/geprc900.md
@@ -126,6 +126,8 @@ Device: `GEPRC Nano 900MHz`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/hglrc-hermes2400.md
+++ b/docs/quick-start/receivers/hglrc-hermes2400.md
@@ -126,7 +126,7 @@ Device: `HGLRC Hermes 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [Wiring Guide] shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 

--- a/docs/quick-start/receivers/hglrc-hermes2400.md
+++ b/docs/quick-start/receivers/hglrc-hermes2400.md
@@ -126,6 +126,8 @@ Device: `HGLRC Hermes 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [Wiring Guide] shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 
 !!! attention ""

--- a/docs/quick-start/receivers/hglrc-hermes900.md
+++ b/docs/quick-start/receivers/hglrc-hermes900.md
@@ -126,6 +126,8 @@ Device: `HGLRC Hermes 900 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/hglrc-hermes900.md
+++ b/docs/quick-start/receivers/hglrc-hermes900.md
@@ -126,7 +126,7 @@ Device: `HGLRC Hermes 900 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/hmep2400.md
+++ b/docs/quick-start/receivers/hmep2400.md
@@ -131,6 +131,8 @@ Device: `HappyModel EP 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [Wiring Guide] shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 
 !!! attention ""

--- a/docs/quick-start/receivers/hmep2400.md
+++ b/docs/quick-start/receivers/hmep2400.md
@@ -131,7 +131,7 @@ Device: `HappyModel EP 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [Wiring Guide] shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 

--- a/docs/quick-start/receivers/hmes900.md
+++ b/docs/quick-start/receivers/hmes900.md
@@ -49,7 +49,7 @@ Device: `HappyModel RX ES900RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [Wiring Guide] shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 

--- a/docs/quick-start/receivers/hmes900.md
+++ b/docs/quick-start/receivers/hmes900.md
@@ -47,7 +47,22 @@ Device: `HappyModel RX ES900RX`
 
 ![via Passthrough](../../assets/images/Method_RX_Passthrough.png)
 
-With the receiver [wired properly] to your FC, select the right target and set your [Firmware Options] in the ExpressLRS Configurator, then click on **Build and Flash**. First time compiles naturally takes a while but if you do the prep work properly, you'll be greeted with the `Success` message soon enough!
+Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
+
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
+You will need to bridge the `Boot` pads on the receiver the first time you'll be updating via this method. The [Wiring Guide] shows where the `Boot` pads are. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
+
+!!! attention ""
+    Note: if you powered the receiver and has solid LED light, your FC is probably pulling the current UART's RX pad `LOW` which will interfere with the normal and passthrough flashing of this receiver. Find another UART and wire your receiver there instead.
+
+These procedures will not be needed in subsequent passthrough flashing. This is only needed on the first time you'd update the receiver from its factory firmware.
+
+Select the corresponding target in the ExpressLRS Configurator, set your [Firmware Options] and then click **Build and Flash**. For first time flashing/updating, it would normally take a while.
+
+![Build & Flash](../../assets/images/BuildFlash.png)
+
+A `Success` message will be shown once the process is complete.
 
 ### Flashing via Wifi
 
@@ -183,3 +198,4 @@ Once done, wire your receiver to your Flight Controller. Passthrough flashing ca
 
 [Firmware Options]: ../firmware-options.md
 [wired properly]: #wiring-up-your-receiver
+[Wiring Guide]: #wiring-up-your-receiver

--- a/docs/quick-start/receivers/hmpp2400.md
+++ b/docs/quick-start/receivers/hmpp2400.md
@@ -36,7 +36,7 @@ Device: `HappyModel PP 2400 RX`
 
 The PP receivers do not have Wifi, and so, it can only be updated via Passthrough or STLink(see below).
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 Once wired, power up your FC by connecting a LiPo or, if the receiver is getting powered via USB, connect your USB cable to a vacant port.
 

--- a/docs/quick-start/receivers/hmpp2400.md
+++ b/docs/quick-start/receivers/hmpp2400.md
@@ -36,6 +36,8 @@ Device: `HappyModel PP 2400 RX`
 
 The PP receivers do not have Wifi, and so, it can only be updated via Passthrough or STLink(see below).
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 Once wired, power up your FC by connecting a LiPo or, if the receiver is getting powered via USB, connect your USB cable to a vacant port.
 
 Using the ExpressLRS Configurator, with the correct Target selected and [Firmware Options] set, hit **Build & Flash**. Wait a bit for the process to finish and you should see a "Success" banner. 

--- a/docs/quick-start/receivers/iflight2400.md
+++ b/docs/quick-start/receivers/iflight2400.md
@@ -129,6 +129,8 @@ Device: `iFlight 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/iflight2400.md
+++ b/docs/quick-start/receivers/iflight2400.md
@@ -129,7 +129,7 @@ Device: `iFlight 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/iflight900.md
+++ b/docs/quick-start/receivers/iflight900.md
@@ -125,6 +125,8 @@ Device: `iFlight 900 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/iflight900.md
+++ b/docs/quick-start/receivers/iflight900.md
@@ -125,7 +125,7 @@ Device: `iFlight 900 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/jumper-aion.md
+++ b/docs/quick-start/receivers/jumper-aion.md
@@ -125,6 +125,8 @@ Device : `Jumper AION Mini 2400 RX`
 
 Make sure you have [wired] your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.

--- a/docs/quick-start/receivers/jumper-aion.md
+++ b/docs/quick-start/receivers/jumper-aion.md
@@ -125,7 +125,7 @@ Device : `Jumper AION Mini 2400 RX`
 
 Make sure you have [wired] your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/matek2400.md
+++ b/docs/quick-start/receivers/matek2400.md
@@ -133,7 +133,7 @@ Device : `Matek 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 Power your FC with a LiPo, or if receiver is powered via USB (receiver is connected to a 4v5 pad), connect the FC to your USB port.
 

--- a/docs/quick-start/receivers/matek2400.md
+++ b/docs/quick-start/receivers/matek2400.md
@@ -133,6 +133,8 @@ Device : `Matek 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 Power your FC with a LiPo, or if receiver is powered via USB (receiver is connected to a 4v5 pad), connect the FC to your USB port.
 
 !!! attention ""

--- a/docs/quick-start/receivers/r9.md
+++ b/docs/quick-start/receivers/r9.md
@@ -89,7 +89,7 @@ Make sure the correct [Bootloader] has been flashed to the receiver prior to wir
 
 Set up your Flight Controller for ExpressLRS. Make sure you have set Serial RX to the right UART (RX & TX Pair) under the Ports Tab. Follow the [FC Configuration Guide].
 
-Once your Flight Controller is configured, you don't need to be connected to Betaflight or INAV Configurator anymore. Close your FC Configurator and unplug the USB to refresh the connection.
+Once your Flight Controller is configured, you should disconnect from Betaflight or INAV Configurator. Close your FC Configurator and unplug the USB to refresh the connection.
 
 Plug in the Flight Controller to USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
 

--- a/docs/quick-start/receivers/r9.md
+++ b/docs/quick-start/receivers/r9.md
@@ -85,11 +85,13 @@ Device:
 
 ![via Passthrough](../../assets/images/Method_RX_Passthrough-stm.png)
 
-Make sure the correct [Bootloader] has been flashed to the receiver prior to wiring it up to your flight controller. Using the wiring guide above, find a free, uninverted UART in your FC. You can use your FC's wiring guide for a Crossfire or Ghost receiver.
+Make sure the correct [Bootloader] has been flashed to the receiver prior to wiring it up to your flight controller. Using the [wiring guide] above, find a free, uninverted UART in your FC. You can use your FC's wiring guide for a Crossfire or Ghost receiver.
 
 Set up your Flight Controller for ExpressLRS. Make sure you have set Serial RX to the right UART (RX & TX Pair) under the Ports Tab. Follow the [FC Configuration Guide].
 
-Once wired to your FC, connect USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
+Once your Flight Controller is configured, you don't need to be connected to Betaflight or INAV Configurator anymore. Close your FC Configurator and unplug the USB to refresh the connection.
+
+Plug in the Flight Controller to USB. Did your receiver powered up too (with both LEDs lit)? If so, disconnect USB, hold the bind button on your receiver, and reconnect to USB. The LED should start alternating between the Green and Red LEDs. Once it's alternating, you can then let go of the Bind Button.
 
 If your receiver didn't get powered from USB, have a lipo ready and continue with the next steps. On the ExpressLRS Configurator, with your [Firmware Options] set, click on **Build & Flash**. Like on the TX module, it will take a while on the first time. Watch out for the `Passthrough Init` stage. This stage will check your FC Configuration for the Serial RX UART (Software Inversion via "set serialrx_inverted" and Half Duplex mode via "set serialrx_halfduplex" will be checked; both should be off.)
 
@@ -160,3 +162,4 @@ Once done, [wire] your receiver to your Flight Controller. Passthrough flashing 
 [wire]: #wiring-it-up
 [Bootloader]: #bootloaders
 [FC Configuration Guide]: ./configuring-fc.md
+[wiring guide]: #wiring-it-up

--- a/docs/quick-start/receivers/radiomaster-rp-2400.md
+++ b/docs/quick-start/receivers/radiomaster-rp-2400.md
@@ -135,7 +135,7 @@ Device: `RadioMaster RP1/2 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 You will need to solder one end of a piece of wire into the Boot pad and the other end into the Ground pad the first time you'll be updating with this method to manually put the receiver into Bootloader mode. The [Wiring Guide] shows where the `Boot` pad is. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 

--- a/docs/quick-start/receivers/radiomaster-rp-2400.md
+++ b/docs/quick-start/receivers/radiomaster-rp-2400.md
@@ -135,6 +135,8 @@ Device: `RadioMaster RP1/2 2400 RX`
 
 Make sure you have your receiver [wired properly]. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 You will need to solder one end of a piece of wire into the Boot pad and the other end into the Ground pad the first time you'll be updating with this method to manually put the receiver into Bootloader mode. The [Wiring Guide] shows where the `Boot` pad is. A solid LED indicates the receiver is in `Bootloader` mode when the TX module is OFF (Solid LED also indicates Radio+module & Receiver is bound and has connection). 
 
 !!! attention ""

--- a/docs/quick-start/receivers/vantac2400.md
+++ b/docs/quick-start/receivers/vantac2400.md
@@ -125,7 +125,7 @@ Device : `Vantac 2400 RX`
 
 Make sure you have [wired] your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
-You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+For the following steps, you should be disconnected from Betaflight or INAV Configurator. Close the FC Configurator and unplug the FC from USB to refresh the connection.
 
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 

--- a/docs/quick-start/receivers/vantac2400.md
+++ b/docs/quick-start/receivers/vantac2400.md
@@ -125,6 +125,8 @@ Device : `Vantac 2400 RX`
 
 Make sure you have [wired] your receiver properly. Rx pad on the Receiver wired up to a Tx pad on the FC, and the Tx pad on the Receiver wired up to an Rx pad on the FC. Also make sure you have setup your FC firmware to use CRSF Protocol, and that the UART is not inverted or running in half duplex.
 
+You don't need to be connected to Betaflight or INAV Configurator during this step. Close your FC Configurator and unplug the USB to refresh the connection.
+
 If the receiver gets powered up when you connect the FC to USB, you will need to Press and Hold the button on the receiver, connect USB and let go of the button once the LED stopped blinking and goes SOLID.
 
 If the receiver needs a LiPo attached to get powered up, then Press and Hold the button on the receiver, attach a LiPo, then let go once the LED in the receiver stopped blinking and goes SOLID. Then connect your FC to USB.


### PR DESCRIPTION
Added the clause for making sure the FC Configurator apps are closed, with the addition of unplugging the USB.