### PR TITLE
Info section changes

### DIFF
--- a/docs/info/advance-technical-info.md
+++ b/docs/info/advance-technical-info.md
@@ -4,7 +4,6 @@ template: main.html
 
 ![Info Banner](https://github.com/ExpressLRS/ExpressLRS-Hardware/blob/master/img/information.png?raw=true)
 
-# Advance Technical Information
 This page explain the more technical side for debugging things yourself.
 
 ## LUA Status

--- a/docs/info/glossary.md
+++ b/docs/info/glossary.md
@@ -4,22 +4,22 @@ template: main.html
 
 ![Info Banner](https://github.com/ExpressLRS/ExpressLRS-Hardware/blob/master/img/information.png?raw=true)
 
-# Glossary
+## Words with explanations
+
 Below you can find a list of terms you might not be sure about, as well as some common abbreviations:
 
-- `CRSF`: TBS Crossfire, more specifialy in our case most often refering to the communication protocol between TX and TX module and RX and FC respectively
-- `OTX`: OpenTX
-- `FW`: Firmware
 - `BL`: Bootloader, loads the FW
-- `S.Port`: SmartPort, sometimes referred to as `sport`. FrSky "telemetry" protocol. The `S.Port` also gets used for updating FrSky receivers.
-- `OTA`: Update your device `Over The Air` (wifi)
+- `CRSF`: TBS Crossfire, more specifialy in our case most often refering to the communication protocol between TX and TX module and RX and FC respectively
+- `FC`: Flight Controller
+- `FW`: Firmware
+- `LQ`: Link Quality, percentage of expected packets received. Our preferred method of measuring the quality of the control link
+- `Lua`: Means "Moon" in Portuguese. As such, Lua is the correct way to write and not all uppercase. The ExpressLRS Lua script can be installed on a OpenTX radio, to easily alter TX parameters like Packet rate, Telemetry ratio and Output power. But also shows if the radio (OpenTX) is communicating correctly with the module. ( e.g. 0:50, 0:150, 0:200 and so on.)
 - `MCU`: Micro Controller Unit, generally denotes an embedded system controller as opposed to big iron cpu
 - `OSD`: On Screen Display, refer to [this page for instructions for setup in BF](../quick-start/pre-1stflight.md#rssi-and-link-quality)
-- `LQ`: Link Quality, percentage of expected packets received. Our preferred method of measuring the quality of the control link
-- `RSSI dBm`: Measure of power level measured in dBm. Basically, how strong the signal being received is
+- `OTA`: Update your device `Over The Air` (wifi)
+- `OTX`: OpenTX
 - `RSSI`: Received Signal Strength Indicator, "arbitrary" scaled version of `RSSI dBm` or LQ. [Signal Health: LQI and RSSI Explained](../info/signal-health.md)
-- `Lua`: Means "Moon" in Portuguese. As such, Lua is the correct way to write and not all uppercase.
-The ExpressLRS Lua script can be installed on a OpenTX radio, to easily alter TX parameters like Packet rate, Telemetry ratio and Output power.
-But also shows if the radio (OpenTX) is communicating correctly with the module. ( e.g. 0:50, 0:150, 0:200 and so on.)
+- `RSSI dBm`: Measure of power level measured in dBm. Basically, how strong the signal being received is
+- `S.Port`: SmartPort, sometimes referred to as `sport`. FrSky "telemetry" protocol. The `S.Port` also gets used for updating FrSky receivers.
 
 To be continued.

--- a/docs/info/glossary.md
+++ b/docs/info/glossary.md
@@ -4,7 +4,7 @@ template: main.html
 
 ![Info Banner](https://github.com/ExpressLRS/ExpressLRS-Hardware/blob/master/img/information.png?raw=true)
 
-## Words with explanations
+## Technical words with explanations
 
 Below you can find a list of terms you might not be sure about, as well as some common abbreviations:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_author: ExpressLRS
 site_description: >-
   ExpressLRS aims to provide the best completely open, high refresh radio
   control link while maintaining a maximum achievable range at that rate with
-  low latency. Vast support of hardware in both 900 Mhz and 2.4 GHz frequencies.
+  low latency. Vast support of hardware in both 900 MHz and 2.4 GHz frequencies.
 
 # Repository
 repo_name: ExpressLRS/ExpressLRS
@@ -163,7 +163,7 @@ nav:
           - Flashing Receivers:
             - Axis Thor: quick-start/receivers/axis-thor.md
             - BetaFPV Lite & Nano 2.4GHz: quick-start/receivers/betafpv2400.md
-            - BetaFPV Nano 900Mhz: quick-start/receivers/betafpv900.md
+            - BetaFPV Nano 900MHz: quick-start/receivers/betafpv900.md
             - Frsky R9: quick-start/receivers/r9.md
             - GEPRC Nano 2.4GHz: quick-start/receivers/geprc2400.md
             - GEPRC Nano 900MHz: quick-start/receivers/geprc900.md


### PR DESCRIPTION
I have made a few meaningful changes.

- Alphabetically ordered the glossary section, removed inline H1 heading, and added H2 level heading for UI consistency
- Updated case of Hz as per SI Unit in the table of content.
- Reviewed and updated advance technical info section for Pages UI consistency