### PR TITLE
Update announce to v3.0.1

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -13,5 +13,5 @@
 {% endblock %}
 
 {% block announce %}
-ExpressLRS v3.0.0 out now! Check it out <a href="https://github.com/ExpressLRS/ExpressLRS/releases/tag/3.0.0">on GitHub.</a>
+ExpressLRS v3.0.1 out now! Check it out <a href="https://github.com/ExpressLRS/ExpressLRS/releases/tag/3.0.1">on GitHub.</a>
 {% endblock %}


### PR DESCRIPTION
Fix the https://www.expresslrs.org/ web-page pop-up to list the latest v3.0.1 instead of v3.0.0