### PR TITLE
Internal Module VCP CLI Mode

### DIFF
--- a/docs/quick-start/transmitters/betfpvlr3pro.md
+++ b/docs/quick-start/transmitters/betfpvlr3pro.md
@@ -19,6 +19,8 @@ template: main.html
 
 - Device: `BETAFPV LiteRadio 3 Pro`
 
+Before starting, make sure that the Serial Ports, USB-VCP setting is set to `CLI` mode on your Radio. This setting can be found in the `System Menu` -> `Hardware` Page.
+
 With your handset turned on, connect a USB data cable to the USB port of the Radio. Select `USB Serial(VCP)` in the options window that pops up. 
 
 <figure markdown>

--- a/docs/quick-start/transmitters/jumper-internal.md
+++ b/docs/quick-start/transmitters/jumper-internal.md
@@ -17,6 +17,8 @@ template: main.html
 !!! tip "Hot Tip"
     To ensure updating success with this method, update the EdgeTX firmware on the radio to at least EdgeTX 2.8.0 (f6d140e, released Nov. 27, 2022). The EdgeTx Firmware that comes with this radio is a pre-release version.
 
+Before starting, make sure that the Serial Ports, USB-VCP setting is set to `CLI` mode on your Radio. This setting can be found in the `System Menu` -> `Hardware` Page.
+
 With your handset turned on, connect a USB data cable to the USB data port of the Radio. Select `USB Serial(Debug)` or `USB Serial(VCP)` in the options window that pops up. 
 
 <figure markdown>

--- a/docs/quick-start/transmitters/rm-internal.md
+++ b/docs/quick-start/transmitters/rm-internal.md
@@ -41,6 +41,8 @@ Before you start, ensure you have the latest EdgeTX firmware version on your Rad
 
 Also make sure you have an internal ELRS module on your Radio. The following steps only applies to handsets with ExpressLRS-specific internal modules. There are stickers marked with "ELRS" attached into your radio packaging or boxes, as well as on the JR module bays indicating the type of internal rf module the radio have.
 
+Also make sure that the Serial Ports, USB-VCP setting is set to `CLI` mode on your Radio. This setting can be found in the `System Menu` -> `Hardware` Page.
+
 With your handset turned on, connect a USB data cable to the USB data port of the Radio. Select `USB Serial(Debug)` or `USB Serial(VCP)` in the options window that pops up. 
 
 <figure markdown>


### PR DESCRIPTION
adding a note regarding the USB-VCP Serial Port mode setting for internal ELRS module flashing/updating