### PR TITLE
vscode devcontainer support for doc development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "name": "Existing docker compose",
+	"dockerComposeFile": [
+		"../compose.yml"
+	],
+    "service": "docs",
+    "workspaceFolder": "/docs"
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ ExpressLRS.org website source code
 You need to have [docker](https://docs.docker.com/engine/install/)
 and [docker-compose](https://docs.docker.com/compose/install/) installed in your environment.
 
+If you edit the docs in vscode when you open the top level directory it will ask if you wish to `Reopen in Container` click that button and vscode will automatically run `docker compose up` which will then start serving the documentation as below, otherwise you can do it manually as below.
+
 Then you need to build your container:
 
 ```


### PR DESCRIPTION
Allows an editor to open the docs in vscode devcontainer which automatically starts the docker container so you can see the live edited site.