### PR TITLE
Update aion-internal.md - fix incorrect word, extend non-ELRS variant warning

### DIFF
--- a/docs/quick-start/transmitters/aion-internal.md
+++ b/docs/quick-start/transmitters/aion-internal.md
@@ -5,7 +5,7 @@ template: main.html
 ![Setup-Banner](https://github.com/ExpressLRS/ExpressLRS-Hardware/raw/master/img/quick-start.png)
 
 !!! danger "Advisory"
-    Not all Jumper T Pros come with an internal ELRS receiver. Some come with a "multi JP4in1 multi-protocol module". This tutorial does not apply to those Jumper T Pros. Check the page you bought it from to determine which unit you purchased.
+    Not all Jumper T Pros come with an internal ELRS transmitter. Some come with a "JP4in1 multi-protocol module" or "CC2500 multi-protocol module". This tutorial does not apply to those Jumper T Pros. Check the page you bought it from to determine which unit you purchased.
 
 !!! danger "Advisory"
     If you are flashing/updating your TX module via WiFi for the first time from the factory firmware, or from an older firmware, to ExpressLRS 3.x firmware, you will first need to flash it to version 2.5.2, then flash it with the [Repartitioner](https://github.com/ExpressLRS/repartitioner) binary [file](https://github.com/ExpressLRS/repartitioner/releases/download/1.0/repartitioner.bin) (right click, save as/save file as). Should it complain about Target Mismatch, just click `Flash Anyway`. Only then you can flash to 3.x firmware via WiFi.


### PR DESCRIPTION
Fixes incorrect word (receiver instead of transmitter) and adds mention of the CC2500 T-Pro variant.