### PR TITLE
Added clause for MSP DisplayPort-capable fpv systems

### DIFF
--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -30,9 +30,19 @@ To get RSSI and Link Quality displayed in the OSD set RSSI Channel to "Disabled"
 
 If you wish to enable the RSSI dBm warning, you'll have to change the alarm level using `set osd_rssi_dbm_alarm = -100` in CLI. A sensible value is 5-10 higher than the sensitivity shown in the ELRS.lua for the packet rate (e.g. 250Hz=-108, so -103 to -98 for the alarm).
 
-If using DJI Goggles, you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab.
+If using DJI Goggles V1 or V2 (unrooted/unmodded), you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab.
 
-More information about signal metrics is found in this great [article on signal health](../info/signal-health.md).
+For digital fpv systems with "canvas mode" or full native OSD support via MSP Displayport (Walksnail Avatar, HDZero, DJI O3), you can treat the config as any analog fpv setup. Therefore, you do NOT have to set RSSI Channel (leave it at disabled; ++"5"++). 
+
+<figure markdown>
+![Conf Tab](../../assets/images/ConfigurationTab.png)
+</figure>
+
+<figure markdown>
+![INAV Config](../../assets/images/FC-rxconfig-INAV.png)
+</figure>
+
+More information about signal metrics can be found in this great [article on signal health](../info/signal-health.md).
 
 ## Bench Test
 

--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -30,9 +30,9 @@ To get RSSI and Link Quality displayed in the OSD set RSSI Channel to "Disabled"
 
 If you wish to enable the RSSI dBm warning, you'll have to change the alarm level using `set osd_rssi_dbm_alarm = -100` in CLI. A sensible value is 5-10 higher than the sensitivity shown in the ELRS.lua for the packet rate (e.g. 250Hz=-108, so -103 to -98 for the alarm).
 
-If using DJI Goggles V1 or V2 (unrooted/unmodded), you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab.
+If using DJI Goggles V1 or V2 (unrooted/unmodded), you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab (see ++"5"++).
 
-For digital fpv systems with "canvas mode" or full native OSD support via MSP Displayport (Walksnail Avatar, HDZero, DJI O3), you can treat the config as any analog fpv setup. Therefore, you do NOT have to set RSSI Channel (leave it at disabled; ++"5"++). 
+For digital FPV systems with "Canvas Mode" or full native OSD support via MSP Displayport (Walksnail Avatar, HDZero, DJI O3), you can treat the config as any analog FPV setup. Therefore, you do NOT have to set RSSI Channel (leave it at disabled; ++"5"++). 
 
 <figure markdown>
 ![Conf Tab](../../assets/images/ConfigurationTab.png)

--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -22,7 +22,9 @@ One important thing to keep in mind is that Aux1 should be used as your Arming s
 
 ## RSSI and Link Quality
 
-To get RSSI and Link Quality displayed in the OSD set RSSI Channel to "Disabled" in the Receiver tab of the Betaflight/iNav Configurator, and RSSI_ADC should be disabled on the Configuration tab. Both of these are the default. On the OSD menu, use the **Link Quality** and **RSSI dBm value** elements (not "RSSI Value"). iNav has put this in the `CRSF RX Statistics` section.
+To get RSSI and Link Quality displayed in the OSD set **RSSI Channel** to {==Disabled==} in the Receiver tab of the Betaflight/INAV Configurator, and **RSSI_ADC** should be {==Disabled==} on the Configuration tab. Both of these are the default.
+
+On the OSD Tab, use the **Link Quality** and **RSSI dBm value** elements (not "RSSI Value"). INAV has put this in the `CRSF RX Statistics` section.
 
 <figure markdown>
 ![OSD](../assets/images/OSD.jpg)

--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -24,6 +24,14 @@ One important thing to keep in mind is that Aux1 should be used as your Arming s
 
 To get RSSI and Link Quality displayed in the OSD, set both **RSSI Channel** and **RSSI_ADC** to {==Disabled==}. Both settings can be found in the Receiver Tab.
 
+<figure markdown>
+![Conf Tab](../../assets/images/ConfigurationTab.png)
+</figure>
+
+<figure markdown>
+![INAV Config](../../assets/images/FC-rxconfig-INAV.png)
+</figure>
+
 On the OSD Tab, use the **Link Quality** and **RSSI dBm value** elements (not "RSSI Value"). INAV has put this in the `CRSF RX Statistics` section.
 
 <figure markdown>
@@ -34,17 +42,9 @@ If you wish to enable the RSSI dBm warning, you'll have to change the alarm leve
 
 Likewise, if you want to change the LQ Alarm level, you can use the CLI command `set osd_link_quality_alarm = x` with `x` as your LQ Alarm level. `60` is a good value to start with.
 
-If you're using DJI Goggles V1 or V2 (unrooted/unmodded), you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab (see ++"5"++).
+If you're using DJI Goggles V1 or V2 (unrooted/unmodded), you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab (see images above).
 
-For digital FPV systems with "Canvas Mode" or full native OSD support via MSP Displayport (Walksnail Avatar, HDZero, DJI O3), you can treat the config as any analog FPV setup. Therefore, you do NOT have to set RSSI Channel (leave it at disabled; ++"5"++). 
-
-<figure markdown>
-![Conf Tab](../../assets/images/ConfigurationTab.png)
-</figure>
-
-<figure markdown>
-![INAV Config](../../assets/images/FC-rxconfig-INAV.png)
-</figure>
+For digital FPV systems with "Canvas Mode" or full native OSD support via MSP Displayport (Walksnail Avatar, HDZero, DJI O3), you can treat the config as any analog FPV setup. Therefore, you do NOT have to set RSSI Channel (leave it at disabled). 
 
 More information about signal metrics can be found in this great [article on signal health](../info/signal-health.md).
 

--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -22,7 +22,7 @@ One important thing to keep in mind is that Aux1 should be used as your Arming s
 
 ## RSSI and Link Quality
 
-To get RSSI and Link Quality displayed in the OSD set **RSSI Channel** to {==Disabled==} in the Receiver tab of the Betaflight/INAV Configurator, and **RSSI_ADC** should be {==Disabled==} on the Configuration tab. Both of these are the default.
+To get RSSI and Link Quality displayed in the OSD, set both **RSSI Channel** and **RSSI_ADC** to {==Disabled==}. Both settings can be found in the Receiver Tab.
 
 On the OSD Tab, use the **Link Quality** and **RSSI dBm value** elements (not "RSSI Value"). INAV has put this in the `CRSF RX Statistics` section.
 
@@ -32,7 +32,9 @@ On the OSD Tab, use the **Link Quality** and **RSSI dBm value** elements (not "R
 
 If you wish to enable the RSSI dBm warning, you'll have to change the alarm level using `set osd_rssi_dbm_alarm = -100` in CLI. A sensible value is 5-10 higher than the sensitivity shown in the ELRS.lua for the packet rate (e.g. 250Hz=-108, so -103 to -98 for the alarm).
 
-If using DJI Goggles V1 or V2 (unrooted/unmodded), you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab (see ++"5"++).
+Likewise, if you want to change the LQ Alarm level, you can use the cli command `set osd_link_quality_alarm = x` with `x` as your LQ alarm level. `60` is a good value to start with.
+
+If you're using DJI Goggles V1 or V2 (unrooted/unmodded), you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab (see ++"5"++).
 
 For digital FPV systems with "Canvas Mode" or full native OSD support via MSP Displayport (Walksnail Avatar, HDZero, DJI O3), you can treat the config as any analog FPV setup. Therefore, you do NOT have to set RSSI Channel (leave it at disabled; ++"5"++). 
 

--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -32,7 +32,7 @@ On the OSD Tab, use the **Link Quality** and **RSSI dBm value** elements (not "R
 
 If you wish to enable the RSSI dBm warning, you'll have to change the alarm level using `set osd_rssi_dbm_alarm = -100` in CLI. A sensible value is 5-10 higher than the sensitivity shown in the ELRS.lua for the packet rate (e.g. 250Hz=-108, so -103 to -98 for the alarm).
 
-Likewise, if you want to change the LQ Alarm level, you can use the cli command `set osd_link_quality_alarm = x` with `x` as your LQ alarm level. `60` is a good value to start with.
+Likewise, if you want to change the LQ Alarm level, you can use the CLI command `set osd_link_quality_alarm = x` with `x` as your LQ Alarm level. `60` is a good value to start with.
 
 If you're using DJI Goggles V1 or V2 (unrooted/unmodded), you're required to use "RSSI Value" as the OSD element. Therefore you have to decide between LQ or RSSI, by selecting either AUX11 (LQ) or AUX12 (RSSI) as RSSI Channel on the Receiver tab (see ++"5"++).
 

--- a/docs/quick-start/receivers/configuring-fc.md
+++ b/docs/quick-start/receivers/configuring-fc.md
@@ -39,7 +39,7 @@ Follow the steps below to set up your Serial Receiver Protocol:
 4. Set `Telemetry` to {==Enabled==}.
     - On INAV, `Telemetry` can be found under the ++"Configuration"++ Tab.
 
-5. Make sure you set `RSSI Channel` to {==Disabled==} if you are using an Analog FPV System.
+5. Make sure you set `RSSI Channel` to {==Disabled==} if you are using an Analog FPV System, or any FPV System with MSP DisplayPort or "Canvas Mode" support.
     - Also make sure `RSSI ADC` is {==Disabled==}.
 
 


### PR DESCRIPTION
With the emergence of full "Canvas Mode" support on the newer digital FPV systems, and the ability to root and modify existing old gen DJI fpv system to add such support, setting up the OSD for Link Stats has drastically changed, rendering these sections outdated and even obsolete.

Not anymore! Here's the updated sections! That probably everyone will still miss.