### PR TITLE
Clarify STM VCP Drivers should be installed for Windows 10

### DIFF
--- a/docs/quick-start/transmitters/aion-internal.md
+++ b/docs/quick-start/transmitters/aion-internal.md
@@ -415,7 +415,7 @@ template: main.html
 
         :material-alert-outline: Yellow Caution Triangles in the Device Manager, or any mention of `<Radio Name> Serial Port` means drivers aren't installed.
 
-        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows Users). 
+        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows 10 Users). 
         
         Once Drivers are installed, check again if the Radio is now being recognized correctly. You may have to first unplug-replug the USB Cable or even reboot your computer.
 

--- a/docs/quick-start/transmitters/betafpvlr3pro.md
+++ b/docs/quick-start/transmitters/betafpvlr3pro.md
@@ -401,7 +401,7 @@ template: main.html
 
         :material-alert-outline: Yellow Caution Triangles in the Device Manager, or any mention of `<Radio Name> Serial Port` means drivers aren't installed.
 
-        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows Users). 
+        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows 10 Users). 
         
         Once Drivers are installed, check again if the Radio is now being recognized correctly. You may have to first unplug-replug the USB Cable or even reboot your computer.
 

--- a/docs/quick-start/transmitters/jumper-internal.md
+++ b/docs/quick-start/transmitters/jumper-internal.md
@@ -395,7 +395,7 @@ template: main.html
 
         :material-alert-outline: Yellow Caution Triangles in the Device Manager, or any mention of `<Radio Name> Serial Port` means drivers aren't installed.
 
-        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows Users). 
+        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows 10 Users). 
         
         Once Drivers are installed, check again if the Radio is now being recognized correctly. You may have to unplug-replug the USB Cable first or even reboot your computer.
 

--- a/docs/quick-start/transmitters/rm-internal.md
+++ b/docs/quick-start/transmitters/rm-internal.md
@@ -409,7 +409,7 @@ template: main.html
 
         :material-alert-outline: Yellow Caution Triangles in the Device Manager, or any mention of `<Radio Name> Serial Port` means drivers aren't installed.
 
-        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows Users). 
+        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows 10 Users). 
         
         Once Drivers are installed, check again if the Radio is now being recognized correctly. You may have to unplug-replug the USB Cable first or even reboot your computer.
 

--- a/docs/quick-start/transmitters/updating.md
+++ b/docs/quick-start/transmitters/updating.md
@@ -427,7 +427,7 @@ description: General Guidelines for ExpressLRS TX Module firmware updating.
 
         :material-alert-outline: Yellow Caution Triangles in the Device Manager, or any mention of `<Radio Name> Serial Port` means drivers aren't installed.
 
-        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows Users). 
+        [Download](https://www.st.com/en/development-tools/stsw-stm32102.html) the Driver package first. Unzip/extract the contents of the package and run/execute (double-click) the installer file (`VCP_V1.5.0_Setup_W7_x64_64bits.exe` for Windows 10 Users). 
         
         Once Drivers are installed, check again if the Radio is now being recognized correctly. You may have to first unplug-replug the USB Cable or even reboot your computer.
 


### PR DESCRIPTION
Many users are confused by the directions to install the STM VCP drivers, as the STM page specifies the drivers are for Windows 7 and not needed for Windows 10. Docs updated to specify the drivers should be installed for Windows 10.

Windows 7 is no longer supported, so I don't think it needs to be mentioned here. 