### PR TITLE
Updates BetaFPV TX backpack information

### DIFF
--- a/docs/hardware/backpack/esp-backpack.md
+++ b/docs/hardware/backpack/esp-backpack.md
@@ -45,7 +45,8 @@ See the tables below for the list of supported devices:
 | NamimnoRC Voyager OLED(ESP version)  | ✔️ Fully supported |
 | Axis Flying THOR  | ✔️ Fully supported |
 | HGLRC Hermes | ❌ Not compatible  |
-| BETAFPV 2.4 TX 1W Micro | ✔️ Fully supported  |
+| BETAFPV 2.4 Micro TX 1W | ✔️ Fully supported  |
+| BETAFPV 2.4 Micro Tx 500mW | ❌ Not compatible  |
 | BETAFPV 2.4 TX | ❌ Not compatible  |
 | BETAFPV 900 TX | ❌ Not compatible  |
 | Radiomaster Zorro  | ✔️ Fully supported |

--- a/docs/hardware/backpack/esp-backpack.md
+++ b/docs/hardware/backpack/esp-backpack.md
@@ -47,8 +47,7 @@ See the tables below for the list of supported devices:
 | HGLRC Hermes | ❌ Not compatible  |
 | BETAFPV 2.4 Micro TX 1W | ✔️ Fully supported  |
 | BETAFPV 2.4 Micro Tx 500mW | ❌ Not compatible  |
-| BETAFPV 2.4 TX | ❌ Not compatible  |
-| BETAFPV 900 TX | ❌ Not compatible  |
+| BETAFPV 900 Micro TX | ❌ Not compatible  |
 | Radiomaster Zorro  | ✔️ Fully supported |
 | Jumper Aion T-Pro Internal | ❌ Not compatible  |
 | Jumper Aion Nano | ❌ Not compatible  |


### PR DESCRIPTION
Make it clear that the BetaFPV Micro TX module supports backpack only for its 1W version, not the 500mW one