### PR TITLE
Update Enable RX WiFi image and make expandable sections more obvious

### DIFF
--- a/docs/quick-start/binding.md
+++ b/docs/quick-start/binding.md
@@ -5,7 +5,7 @@ description: Binding ExpressLRS is easy! With the Binding Phrase, no button pres
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/quick-start.png)
 
-??? note "Compatibility (click to expand)"
+??? note "Compatibility (click/tap to expand)"
     The first number in the Version string should match between a TX Module and a Receiver. Examples:
 
     - a TX Module with version string of 3.1.2 will sync and work with a Receiver with firmware version 3.0.1
@@ -48,7 +48,7 @@ Alternatively, you can also change the Binding Phrase via the WebUI if your devi
 
 We recommend using a **unique** phrase with at least 8 alpha-numeric characters. The best candidate is your Pilot Handle. This phrase need not be complicated or super-secret as it isn't a password or encryption key. 
 
-??? info "Is my binding phrase a secret? (click to expand)"
+??? info "Is my binding phrase a secret? (click/tap to expand)"
     No, just like what channel your VTX is on is not a secret. The binding phrase is not for security, it is for anti-collision. If everyone kept their VTX channel a secret, the chances of you blasting someone out of the sky accidentally are pretty high. To provide the best chance of not interfering with other pilots and them not interfering with you, be sure you're not using the same dumb bind phrase as someone else. Express your style and some creativity with a hilarious or saucy bind phrase.
 
 ## Traditional Binding
@@ -64,7 +64,7 @@ The Receiver LED should also be blinking when powered up.
 ![LEDSEQ_DISCONNECTED](https://cdn.discordapp.com/attachments/738450139693449258/921065812985520268/LEDSEQ_DISCONNECTED_50_50.gif)
 </figure>
 
-??? danger "Receiver LED doesn't Blink (click to expand)"
+??? danger "Receiver LED doesn't Blink (click/tap to expand)"
     Here are the things you can do if the Receiver is in Bootloader Mode:
 
     1. Check if the Boot button on the Receiver is being pressed or if it's damaged.
@@ -145,7 +145,7 @@ Using the [ExpressLRS Lua Script](transmitters/lua-howto.md), look for a `C` in 
     ![Lua Loaded](../assets/images/tx-internalLuaCheck.jpg)
     </figure>
 
-??? tip "Model Mismatch (click to expand)"
+??? tip "Model Mismatch (click/tap to expand)"
     If the ExpressLRS Lua Script is showing a `C` in the top-right corner alright, but then that line disappears and is replaced with a line saying "Model Mismatch", do not worry. ExpressLRS has detected that the set Model ID in the Receiver is different from the Receiver ID set in the current Model in your Radio Model Configuration.
 
     This is also indicated by the Receiver LED as 3 fast blinks then a pause:

--- a/docs/quick-start/receivers/axisflying-thor.md
+++ b/docs/quick-start/receivers/axisflying-thor.md
@@ -574,7 +574,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/axisflying-thor.md
+++ b/docs/quick-start/receivers/axisflying-thor.md
@@ -118,7 +118,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -275,7 +275,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -287,7 +287,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -419,7 +419,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -427,7 +427,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -525,7 +525,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/betafpv-superd.md
+++ b/docs/quick-start/receivers/betafpv-superd.md
@@ -563,7 +563,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/betafpv-superd.md
+++ b/docs/quick-start/receivers/betafpv-superd.md
@@ -107,7 +107,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -264,7 +264,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -276,7 +276,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -408,7 +408,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -416,7 +416,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -514,7 +514,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/betafpv-superd900.md
+++ b/docs/quick-start/receivers/betafpv-superd900.md
@@ -563,7 +563,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/betafpv-superd900.md
+++ b/docs/quick-start/receivers/betafpv-superd900.md
@@ -107,7 +107,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -264,7 +264,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -276,7 +276,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -408,7 +408,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -416,7 +416,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -514,7 +514,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/betafpv2400.md
+++ b/docs/quick-start/receivers/betafpv2400.md
@@ -588,7 +588,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/betafpv2400.md
+++ b/docs/quick-start/receivers/betafpv2400.md
@@ -125,7 +125,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -285,7 +285,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -297,7 +297,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -431,7 +431,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -439,7 +439,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -537,7 +537,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/betafpv900.md
+++ b/docs/quick-start/receivers/betafpv900.md
@@ -574,7 +574,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/betafpv900.md
+++ b/docs/quick-start/receivers/betafpv900.md
@@ -118,7 +118,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -275,7 +275,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -287,7 +287,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -419,7 +419,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -427,7 +427,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -525,7 +525,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/firmware-version.md
+++ b/docs/quick-start/receivers/firmware-version.md
@@ -72,7 +72,7 @@ It is still recommended that you update your gear to the latest firmware version
         - If your Receiver is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
         - `expresslrs` is the Password for this Access Point.
 
-        ??? question "Where's the Access Point?"
+        ??? question "Where's the Access Point? (click/tap to expand)"
             If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also, try putting the devices closer together.
                 
             If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -92,7 +92,7 @@ It is still recommended that you update your gear to the latest firmware version
             !!! Note
                 If your browser cannot resolve this address, chances are MDNS is not set up and working on your computer or network.
 
-            ??? tip "Use the IP Address instead!"
+            ??? tip "Use the IP Address instead! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/receivers/firmware-version.md
+++ b/docs/quick-start/receivers/firmware-version.md
@@ -187,5 +187,5 @@ For the latest ExpressLRS firmware version, check the [Releases page in Git Hub]
     See the [Binding Procedure](../binding.md) to sync your Receiver with your TX Module.
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [WiFi Hotspot]: ../../assets/images/WifiHotspot.png

--- a/docs/quick-start/receivers/flash2400.md
+++ b/docs/quick-start/receivers/flash2400.md
@@ -147,7 +147,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -306,7 +306,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -318,7 +318,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -451,7 +451,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -459,7 +459,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -557,7 +557,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/flash2400.md
+++ b/docs/quick-start/receivers/flash2400.md
@@ -718,7 +718,7 @@ Some of the following procedures will not go through, particularly the via Passt
     10. Rewire your receiver to your Flight Controller.
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/foxeer2400.md
+++ b/docs/quick-start/receivers/foxeer2400.md
@@ -579,7 +579,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/foxeer2400.md
+++ b/docs/quick-start/receivers/foxeer2400.md
@@ -119,7 +119,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -278,7 +278,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -290,7 +290,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -423,7 +423,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -431,7 +431,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -529,7 +529,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/geprc2400.md
+++ b/docs/quick-start/receivers/geprc2400.md
@@ -579,7 +579,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/geprc2400.md
+++ b/docs/quick-start/receivers/geprc2400.md
@@ -123,7 +123,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -280,7 +280,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -292,7 +292,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -424,7 +424,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -432,7 +432,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -530,7 +530,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/geprc900.md
+++ b/docs/quick-start/receivers/geprc900.md
@@ -574,7 +574,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/geprc900.md
+++ b/docs/quick-start/receivers/geprc900.md
@@ -118,7 +118,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -275,7 +275,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -287,7 +287,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -419,7 +419,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -427,7 +427,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -525,7 +525,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/hglrc-hermes2400.md
+++ b/docs/quick-start/receivers/hglrc-hermes2400.md
@@ -574,7 +574,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/hglrc-hermes2400.md
+++ b/docs/quick-start/receivers/hglrc-hermes2400.md
@@ -118,7 +118,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -275,7 +275,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -287,7 +287,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -419,7 +419,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -427,7 +427,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -525,7 +525,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/hglrc-hermes900.md
+++ b/docs/quick-start/receivers/hglrc-hermes900.md
@@ -574,7 +574,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/hglrc-hermes900.md
+++ b/docs/quick-start/receivers/hglrc-hermes900.md
@@ -118,7 +118,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -275,7 +275,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -287,7 +287,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -419,7 +419,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -427,7 +427,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -525,7 +525,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/hmep2400.md
+++ b/docs/quick-start/receivers/hmep2400.md
@@ -584,7 +584,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/hmep2400.md
+++ b/docs/quick-start/receivers/hmep2400.md
@@ -118,7 +118,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -280,7 +280,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -292,7 +292,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -428,7 +428,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -436,7 +436,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -534,7 +534,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/hmes900.md
+++ b/docs/quick-start/receivers/hmes900.md
@@ -120,7 +120,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -282,7 +282,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -294,7 +294,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -430,7 +430,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -438,7 +438,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -536,7 +536,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/hmes900.md
+++ b/docs/quick-start/receivers/hmes900.md
@@ -697,7 +697,7 @@ Some of the following procedures will not go through, particularly the via Passt
     10. Rewire your receiver to your Flight Controller.
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/iflight2400.md
+++ b/docs/quick-start/receivers/iflight2400.md
@@ -579,7 +579,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/iflight2400.md
+++ b/docs/quick-start/receivers/iflight2400.md
@@ -123,7 +123,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -280,7 +280,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -292,7 +292,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -424,7 +424,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -432,7 +432,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -530,7 +530,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/iflight900.md
+++ b/docs/quick-start/receivers/iflight900.md
@@ -574,7 +574,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/iflight900.md
+++ b/docs/quick-start/receivers/iflight900.md
@@ -118,7 +118,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -275,7 +275,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -287,7 +287,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -419,7 +419,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -427,7 +427,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -525,7 +525,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/jumper-aion.md
+++ b/docs/quick-start/receivers/jumper-aion.md
@@ -123,7 +123,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -282,7 +282,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -294,7 +294,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -427,7 +427,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -435,7 +435,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -533,7 +533,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/jumper-aion.md
+++ b/docs/quick-start/receivers/jumper-aion.md
@@ -583,7 +583,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/matek2400.md
+++ b/docs/quick-start/receivers/matek2400.md
@@ -124,7 +124,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -283,7 +283,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -295,7 +295,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -428,7 +428,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -436,7 +436,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -534,7 +534,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/matek2400.md
+++ b/docs/quick-start/receivers/matek2400.md
@@ -584,7 +584,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/radiomaster-rp-2400.md
+++ b/docs/quick-start/receivers/radiomaster-rp-2400.md
@@ -130,7 +130,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -291,7 +291,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -303,7 +303,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -437,7 +437,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -445,7 +445,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -543,7 +543,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/radiomaster-rp-2400.md
+++ b/docs/quick-start/receivers/radiomaster-rp-2400.md
@@ -594,7 +594,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/updating.md
+++ b/docs/quick-start/receivers/updating.md
@@ -506,7 +506,7 @@ description: General Guidelines for ExpressLRS Receiver firmware updating.
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/updating.md
+++ b/docs/quick-start/receivers/updating.md
@@ -76,7 +76,7 @@ description: General Guidelines for ExpressLRS Receiver firmware updating.
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -220,7 +220,7 @@ description: General Guidelines for ExpressLRS Receiver firmware updating.
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -232,7 +232,7 @@ description: General Guidelines for ExpressLRS Receiver firmware updating.
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -357,7 +357,7 @@ description: General Guidelines for ExpressLRS Receiver firmware updating.
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -365,7 +365,7 @@ description: General Guidelines for ExpressLRS Receiver firmware updating.
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -463,7 +463,7 @@ description: General Guidelines for ExpressLRS Receiver firmware updating.
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/vantac2400.md
+++ b/docs/quick-start/receivers/vantac2400.md
@@ -574,7 +574,7 @@ Some of the following procedures will not go through, particularly the via Passt
             </figure>
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/vantac2400.md
+++ b/docs/quick-start/receivers/vantac2400.md
@@ -118,7 +118,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -275,7 +275,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -287,7 +287,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -419,7 +419,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -427,7 +427,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -525,7 +525,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/voyager900.md
+++ b/docs/quick-start/receivers/voyager900.md
@@ -686,7 +686,7 @@ Some of the following procedures will not go through, particularly the via Passt
     10. Rewire your receiver to your Flight Controller.
 
 [Lua Running]: ../../assets/images/lua/config-bw.png
-[Lua WiFi]: ../../assets/images/lua/wifi-bw.png
+[Lua WiFi]: ../../assets/images/lua/wifi-bw-rx.png
 [Configurator Release]: ../../assets/images/ConfiguratorRelease.png
 [Temp RX]: ../../assets/images/build-temp-rx.png
 [Flash]: ../../assets/images/BuildFlash.png

--- a/docs/quick-start/receivers/voyager900.md
+++ b/docs/quick-start/receivers/voyager900.md
@@ -119,7 +119,7 @@ Some of the following procedures will not go through, particularly the via Passt
     3. Plug in your UART Adapter into a USB Port on your Computer.
         - The LED on the Receiver should light up Solid. If it's Blinking, repeat the previous step.
 
-        ??? Warning "Receiver LED already Solid"
+        ??? Warning "Receiver LED already Solid (click/tap to expand)"
             If the Receiver LED has become Solid from a failed update, and you're reflashing through this method, you still need to do the previous step: Manually putting the receiver into Bootloader Mode. This ensures the Receiver is indeed in a Bootloader state rather than some random boot loop.
         
     4. Determine whether your UART Adapter is being detected correctly as a USB-to-UART Device.
@@ -276,7 +276,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -288,7 +288,7 @@ Some of the following procedures will not go through, particularly the via Passt
             - If your Receiver is flashed or configured with your Home WiFi SSID and Password, and can connect to that WiFi Network, then the Access Point will not appear.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -420,7 +420,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.
@@ -428,7 +428,7 @@ Some of the following procedures will not go through, particularly the via Passt
         8. With your receiver now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_rx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -526,7 +526,7 @@ Some of the following procedures will not go through, particularly the via Passt
                     ![LEDSEQ_WIFI_UPDATE](https://cdn.discordapp.com/attachments/738450139693449258/921065813983760384/LEDSEQ_WIFI_UPDATE_2_3.gif)
                     </figure>
 
-            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode!"
+            ??? Warning "My Receiver has Solid LED and won't go into WiFi Mode! (click/tap to expand)"
                 Go back to the [Receiver Wiring] step.
                 
                 If you have previously attempted updating your receiver, there's a possibility it was soft-bricked. Go over the [Unbricking] procedure to recover it.

--- a/docs/quick-start/receivers/wiring-up.md
+++ b/docs/quick-start/receivers/wiring-up.md
@@ -23,7 +23,7 @@ Here's a typical ExpressLRS Receiver pinout indicating to which Flight Controlle
 
 The TX pin of an ExpressLRS Receiver sends or transmits the Control Signals it received from the Radio to the Flight Controller. Meanwhile, the RX pin of an ExpressLRS Receiver accepts or receives the Telemetry Data (like Battery Voltage, Current Draw, GPS Coordinates and/or Craft Attitude) from the Flight Controller for sending back to the Radio Handset.
 
-??? Tip "What's a UART?"
+??? Tip "What's a UART? (click/tap to expand)"
     A UART is a pair of RX and TX pads on the Flight Controller. It's commonplace to refer to it as your Flight Controller's USB ports where you can connect different peripherals like a GPS or a Receiver. Only one device can occupy a UART and it can only do one function.
 
     R3 and T3 belongs to UART3; RX2 and TX2 belongs to UART2. Flight Controller Manufacturers label their UARTs differently. Some use just "R" and "T" followed by the UART number. Others use "RX" and "TX" followed by the UART number.
@@ -77,7 +77,7 @@ If your receiver has the RGB LED (e.g. Foxeer LNA, BetaFPV SuperD, Happymodel EP
 
 If your Receiver LED lights up but it's just a Solid light, it is in Bootloader mode as the chart above indicates.
 
-??? danger "My Receiver is in Bootloader Mode!"
+??? danger "My Receiver is in Bootloader Mode! (click/tap to expand)"
 
     Here are the things you can do if the Receiver is in Bootloader Mode:
 

--- a/docs/quick-start/transmitters/aion-internal.md
+++ b/docs/quick-start/transmitters/aion-internal.md
@@ -106,7 +106,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -215,7 +215,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -345,7 +345,7 @@ template: main.html
     !!! tip "Hot Tip"
         To ensure updating success with this method, update the EdgeTX firmware on the radio to at least EdgeTX 2.7.1 (a55aff0). The EdgeTx Firmware that comes with this radio is a pre-release version.
 
-    ??? Tip "Simplest EdgeTX Updating Procedure"
+    ??? Tip "Simplest EdgeTX Updating Procedure (click/tap to expand)"
         1. Visit http://buddy.edgetx.org/.
         2. Select the EdgeTX version and the Radio Model you want to update from the Left-hand side column.
         3. Click the ++"Download .bin"++ button at the bottom of the page.

--- a/docs/quick-start/transmitters/axisflying-thor.md
+++ b/docs/quick-start/transmitters/axisflying-thor.md
@@ -103,7 +103,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -212,7 +212,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/betafpv2400.md
+++ b/docs/quick-start/transmitters/betafpv2400.md
@@ -105,7 +105,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -216,7 +216,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/betafpv900.md
+++ b/docs/quick-start/transmitters/betafpv900.md
@@ -104,7 +104,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -214,7 +214,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/betafpvlr3pro.md
+++ b/docs/quick-start/transmitters/betafpvlr3pro.md
@@ -103,7 +103,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -212,7 +212,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -343,7 +343,7 @@ template: main.html
     !!! tip "Hot Tip"
         To ensure updating success with this method, update the EdgeTX firmware on the radio to at least EdgeTX 2.8.0 (f6d140e, released Nov. 27, 2022). The EdgeTx Firmware that comes with this radio is a pre-release version.
 
-    ??? Tip "Simplest EdgeTX Updating Procedure"
+    ??? Tip "Simplest EdgeTX Updating Procedure (click/tap to expand)"
         1. Visit http://buddy.edgetx.org/.
         2. Select the EdgeTX version and the Radio Model you want to update from the Left-hand side column.
         3. Click the ++"Download .bin"++ button at the bottom of the page.

--- a/docs/quick-start/transmitters/emax2400.md
+++ b/docs/quick-start/transmitters/emax2400.md
@@ -100,7 +100,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -210,7 +210,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/emax900.md
+++ b/docs/quick-start/transmitters/emax900.md
@@ -100,7 +100,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -210,7 +210,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/es24tx.md
+++ b/docs/quick-start/transmitters/es24tx.md
@@ -108,7 +108,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -219,7 +219,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/es900tx.md
+++ b/docs/quick-start/transmitters/es900tx.md
@@ -103,7 +103,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -212,7 +212,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -439,7 +439,7 @@ template: main.html
 
     10. Highlight the file and press-hold the ++"Enter"++ button and select "Flash External ELRS". Wait for the firmware to be written.
 
-        ??? tip "No Sync"
+        ??? tip "No Sync (click/tap to expand)"
             - Make sure you have updated the OpenTX/EdgeTX firmware of your radio to a newer version
             - Make sure the current model selected on the radio is set up for ExpressLRS Use. See the [Radio Preparation] guide.
 

--- a/docs/quick-start/transmitters/firmware-version.md
+++ b/docs/quick-start/transmitters/firmware-version.md
@@ -96,7 +96,7 @@ There are three methods to determine what firmware version you currently have on
         - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
         - `expresslrs` is the Password for this Access Point.
 
-        ??? question "Where's the Access Point?"
+        ??? question "Where's the Access Point? (click/tap to expand)"
             If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also, try putting the devices closer together.
                 
             If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -116,7 +116,7 @@ There are three methods to determine what firmware version you currently have on
             !!! Note
                 If your browser cannot resolve this address, chances are MDNS is not set up and working on your computer or network.
 
-            ??? tip "Use the IP Address instead!"
+            ??? tip "Use the IP Address instead! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/flash2400.md
+++ b/docs/quick-start/transmitters/flash2400.md
@@ -105,7 +105,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -214,7 +214,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -442,7 +442,7 @@ template: main.html
 
     10. Highlight the file and press-hold the ++"Enter"++ button and select "Flash External ELRS". Wait for the firmware to be written.
 
-        ??? tip "No Sync"
+        ??? tip "No Sync (click/tap to expand)"
             - Make sure you have updated the OpenTX/EdgeTX firmware of your radio to a newer version
             - Make sure the current model selected on the radio is set up for ExpressLRS Use. See the [Radio Preparation] guide.
 

--- a/docs/quick-start/transmitters/frsky-r9modules.md
+++ b/docs/quick-start/transmitters/frsky-r9modules.md
@@ -82,7 +82,7 @@ template: main.html
 
     12. Highlight the file and press-hold the ++"Enter"++ button and select "Flash External ELRS". Wait for the firmware to be written.
 
-        ??? tip "No Sync"
+        ??? tip "No Sync (click/tap to expand)"
             - Make sure you have updated the OpenTX/EdgeTX firmware of your radio to a newer version
             - Make sure the current model selected on the radio is set up for ExpressLRS Use. See the [Radio Preparation] guide.
 

--- a/docs/quick-start/transmitters/ghost2400.md
+++ b/docs/quick-start/transmitters/ghost2400.md
@@ -132,7 +132,7 @@ template: main.html
 
     10. Highlight the file and press-hold the ++"Enter"++ button and select "Flash External ELRS". Wait for the firmware to be written.
 
-        ??? tip "No Sync"
+        ??? tip "No Sync (click/tap to expand)"
             - Make sure you have updated the OpenTX/EdgeTX firmware of your radio to a newer version
             - Make sure the current model selected on the radio is set up for ExpressLRS Use. See the [Radio Preparation] guide.
 

--- a/docs/quick-start/transmitters/hglrc-hermes.md
+++ b/docs/quick-start/transmitters/hglrc-hermes.md
@@ -103,7 +103,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -212,7 +212,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/iflight-commando.md
+++ b/docs/quick-start/transmitters/iflight-commando.md
@@ -110,7 +110,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -221,7 +221,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/jumper-aion.md
+++ b/docs/quick-start/transmitters/jumper-aion.md
@@ -103,7 +103,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -212,7 +212,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/jumper-internal.md
+++ b/docs/quick-start/transmitters/jumper-internal.md
@@ -97,7 +97,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -206,7 +206,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -336,7 +336,7 @@ template: main.html
     !!! tip "Hot Tip"
         To ensure updating success with this method, update the EdgeTX firmware on the radio to at least EdgeTX 2.8.0 (f6d140e, released Nov. 27, 2022). The EdgeTx Firmware that comes with this radio is a pre-release version.
 
-    ??? Tip "Simplest EdgeTX Updating Procedure"
+    ??? Tip "Simplest EdgeTX Updating Procedure (click/tap to expand)"
         1. Visit http://buddy.edgetx.org/.
         2. Select the EdgeTX version and the Radio Model you want to update from the Left-hand side column.
         3. Click the ++"Download .bin"++ button at the bottom of the page.

--- a/docs/quick-start/transmitters/jumper-t20-internal.md
+++ b/docs/quick-start/transmitters/jumper-t20-internal.md
@@ -106,7 +106,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -212,7 +212,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -336,7 +336,7 @@ template: main.html
 
     For any of the variants of the `Jumper T20`, the EdgeTX firmware that came with it (pre EdgeTX 2.9.0) should work fine and there's no need to update it.
 
-    ??? Tip "Simplest EdgeTX Updating Procedure"
+    ??? Tip "Simplest EdgeTX Updating Procedure (click/tap to expand)"
         1. Visit http://buddy.edgetx.org/.
         2. Select the EdgeTX version and the Radio Model you want to update from the Left-hand side column.
         3. Click the ++"Download .bin"++ button at the bottom of the page.

--- a/docs/quick-start/transmitters/lua-howto.md
+++ b/docs/quick-start/transmitters/lua-howto.md
@@ -32,7 +32,7 @@ Access the script by navigating to your radio's System Menu.
 
 3. Press ++enter++ to Load it.
 
-??? failure "Stuck at `Loading...` (click to expand)"
+??? failure "Stuck at `Loading...` (click/tap to expand)"
     Go back to the [Radio Preparation Guide](tx-prep.md) and make sure the current model is configured for ExpressLRS use.
 
     Also set your Internal or External RF Baudrate to a higher value if the Script still doesn't load after proper configuration of your Model. 

--- a/docs/quick-start/transmitters/rm-internal.md
+++ b/docs/quick-start/transmitters/rm-internal.md
@@ -105,7 +105,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -214,7 +214,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -348,7 +348,7 @@ template: main.html
     !!! tip "Hot Tip"
         To ensure updating success with this method, update the EdgeTX firmware on the radio as mentioned above.
 
-    ??? Tip "Simplest EdgeTX Updating Procedure"
+    ??? Tip "Simplest EdgeTX Updating Procedure (click/tap to expand)"
         1. Visit http://buddy.edgetx.org/.
         2. Select the EdgeTX version and the Radio Model you want to update from the Left-hand side column.
         3. Click the ++"Download .bin"++ button at the bottom of the page.

--- a/docs/quick-start/transmitters/rm-ranger.md
+++ b/docs/quick-start/transmitters/rm-ranger.md
@@ -101,7 +101,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -212,7 +212,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/siyifm30.md
+++ b/docs/quick-start/transmitters/siyifm30.md
@@ -93,7 +93,7 @@ Updates are done through OpenTX's built-in firmware flashing tool.
 
 ### <span class="custom-heading" data-id="1">Unable to connect to the target device</span>
 
-??? Note "Unable to connect to the target device"
+??? Note "Unable to connect to the target device (click/tap to expand)"
     If the flash fails with "Unable to connect to target device" (not "No STLINK found!") it is likely your STLINK clone does not have the RST line connected, but you can trigger the needed reset manually with a little more effort. The reason this is needed is that SIYI has disabled "Software Reset" to protect you from stealing their firmware binary.
 
     * Verify your wiring
@@ -104,7 +104,7 @@ Updates are done through OpenTX's built-in firmware flashing tool.
 
 ### <span class="custom-heading" data-id="2">Flash loader run error</span>
 
-??? Note "Flash loader run error"
+??? Note "Flash loader run error (click/tap to expand)"
     Before both the TX and RX can be flashed using the `st-flash` utility used by PlatformIO on Linux, the STM32 chip must have its "Readout Protection" (RDP) disabled, which was set by SIYI at the factory to make our lives more difficult. The windows flashing utility usually automatically disables this, but the Linux utility does not. If you do not disable readout protection you'll get this cryptic error when flashing:
     ```
     2021-07-06T21:08:42 ERROR flash_loader.c: flash loader run error

--- a/docs/quick-start/transmitters/tx-prep.md
+++ b/docs/quick-start/transmitters/tx-prep.md
@@ -61,7 +61,7 @@ If you have an older version, please first update your Radio OS to at least the 
 
 ExpressLRS highly recommends [EdgeTX](https://github.com/EdgeTX/edgetx/releases) for the best experience and compatibility. EdgeTX has introduced options that old and new Radio handsets will benefit from, like One Bit Sample Mode (mainly for old Frsky Radios like the X9D and the QX7) and Mega Bauds (baud rates higher than 400K).
 
-??? Tip "Simplest EdgeTX Updating Procedure"
+??? Tip "Simplest EdgeTX Updating Procedure (click/tap to expand)"
     1. Visit http://buddy.edgetx.org/.
     2. Select the EdgeTX version and the Radio Model you want to update from the Left-hand side column.
     3. Click the ++"Download .bin"++ button at the bottom of the page.
@@ -184,7 +184,7 @@ To check and change this setting, follow these steps:
 3. Scroll down until you reach the `ADC Filter` setting.
 4. Press ++enter++ Key to toggle it On or Off.
 
-??? info "EdgeTX 2.7.0 Per-model Settings"
+??? info "EdgeTX 2.7.0 Per-model Settings (click/tap to expand)"
 
     With EdgeTX 2.7 or newer, you can set this per model (Global, On, Off) as this is helpful on Fixed Wing models equipped with PWM receivers connected to slower servos.
 
@@ -241,7 +241,7 @@ ExpressLRS uses the CRSF serial protocol to communicate between the transmitter 
     6. Scroll down until you reach the External RF settings. Set this to Off.
     7. Press the ++"RTN"++ Key or Exit the Model Menu
 
-    ??? info "No CRSF Mode Option?"
+    ??? info "No CRSF Mode Option? (click/tap to expand)"
         If for some reason, you cannot find the CRSF Protocol under the Internal RF Modes, set the `Internal Module Type` to CRSF via your Radio's `System Menu -> Hardware` page.
 
         1. Press the ++"SYS"++ Key. 

--- a/docs/quick-start/transmitters/updating.md
+++ b/docs/quick-start/transmitters/updating.md
@@ -90,7 +90,7 @@ description: General Guidelines for ExpressLRS TX Module firmware updating.
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -192,7 +192,7 @@ description: General Guidelines for ExpressLRS TX Module firmware updating.
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -369,7 +369,7 @@ description: General Guidelines for ExpressLRS TX Module firmware updating.
     - `Jumper T-Pro`: Update it to at least EdgeTX 2.7.1 (a55aff0) for full EdgeTX support.
     - `Jumper T-Lite V2`: Update it to at least EdgeTX 2.8.0 (f6d140e) for full EdgeTX support.
 
-    ??? Tip "Simplest EdgeTX Updating Procedure"
+    ??? Tip "Simplest EdgeTX Updating Procedure (click/tap to expand)"
         1. Visit http://buddy.edgetx.org/.
         2. Select the EdgeTX version and the Radio Model you want to update from the Left-hand side column.
         3. Click the ++"Download .bin"++ button at the bottom of the page.

--- a/docs/quick-start/transmitters/vantac-lite.md
+++ b/docs/quick-start/transmitters/vantac-lite.md
@@ -103,7 +103,7 @@ template: main.html
             - If your TX Module is previously flashed with your Home WiFi SSID and Password, and it is able to connect to that WiFi Network, then the Access Point will not show up.
             - `expresslrs` is the Password for this Access Point.
 
-            ??? question "Where's the Access Point?"
+            ??? question "Where's the Access Point? (click/tap to expand)"
                 If you cannot find the Access Point, make sure the device you're using is capable of connecting to 2.4GHz WiFi Networks. Also try putting the devices closer together.
                 
                 If you still cannot find the Access Point, chances are that you have set it with your WiFi SSID and Password before, and it has connected to your WiFi Network.
@@ -212,7 +212,7 @@ template: main.html
         13. With your module now in WiFi Mode and it was able to connect to your Local WiFi Network, open a Browser window on any WiFi-capable device that is also connected to the same Local WiFi Network. Type in the Address http://elrs_tx.local on your browser's Address Bar. The ExpressLRS Web UI should load.
             - If your browser cannot resolve this address and it cannot load the ExpressLRS Web UI, this means that MDNS is not working on your device or network.
 
-            ??? tip "MDNS is not working!"
+            ??? tip "MDNS is not working! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/quick-start/transmitters/voyager900.md
+++ b/docs/quick-start/transmitters/voyager900.md
@@ -56,7 +56,7 @@ template: main.html
 
     10. Highlight the file and press-hold the ++"Enter"++ button and select "Flash External ELRS". Wait for the firmware to be written.
 
-        ??? tip "No Sync"
+        ??? tip "No Sync (click/tap to expand)"
             - Make sure you have updated the OpenTX/EdgeTX firmware of your radio to a newer version
             - Make sure the current model selected on the radio is set up for ExpressLRS Use. See the [Radio Preparation] guide.
 

--- a/docs/quick-start/unbricking.md
+++ b/docs/quick-start/unbricking.md
@@ -71,7 +71,7 @@ Follow the steps below very closely to recover your "bricked" Receiver.
     ![Passthrough Done](../assets/images/passthrough-done.jpg)
     </figure>
 
-    ??? tip "Not Seeing PASSTHROUGH DONE?"
+    ??? tip "Not Seeing PASSTHROUGH DONE? (click/tap to expand)"
         You've probably skipped some of the steps above or you've misconfigured your flight controller. Go back and make sure to follow EVERY step.
 
 10. Plug in LiPo or twist the 5v Wires together to power up the receiver (see Step 1). The receiver LED should be Solid.

--- a/docs/quick-start/webui.md
+++ b/docs/quick-start/webui.md
@@ -162,7 +162,7 @@ This section is currently only available for the RadioMaster Ranger module.
             6. Select `Enable RX WiFi` and press ++enter++.
 
                 <figure markdown>
-                ![Lua WiFi]
+                ![Lua WiFi RX]
                 </figure>
 
             7. The `WiFi Running` screen will briefly show up. Your Receiver is now in WiFi mode as indicated by the rapidly blinking LED.
@@ -290,3 +290,4 @@ This section is currently only available for the RadioMaster Ranger module.
 [Lua Script]: ../assets/images/lua1.jpg
 [Lua Running]: ../assets/images/lua/config-bw.png
 [Lua WiFi]: ../assets/images/lua/wifi-bw.png
+[Lua WiFi RX]: ../../assets/images/lua/wifi-bw-rx.png

--- a/docs/quick-start/webui.md
+++ b/docs/quick-start/webui.md
@@ -123,7 +123,7 @@ This section is currently only available for the RadioMaster Ranger module.
                 ![RX Waiting](https://cdn.discordapp.com/attachments/738450139693449258/921065812985520268/LEDSEQ_DISCONNECTED_50_50.gif)
                 </figure>
 
-                ??? warning "Receiver LED not Blinking!"
+                ??? warning "Receiver LED not Blinking! (click/tap to expand)"
                     If it has a Solid LED light, it may be in bootloader mode if you've only just wired it up. [Rewire](../quick-start/receivers/wiring-up.md) your receiver into a different uart. If you have attempted to update it before, then it could be soft-bricked. Follow the [Unbricking](../quick-start/unbricking.md) procedure to get it back into normal working condition.
 
             3. Wait for about 60 seconds or until the Receiver LED blinks rapidly indicating it is now in WiFi Mode.
@@ -198,7 +198,7 @@ This section is currently only available for the RadioMaster Ranger module.
             !!! Note
                 If your browser cannot resolve this address, chances are MDNS is not set up and working on your computer or network.
 
-            ??? tip "Use the IP Address instead!"
+            ??? tip "Use the IP Address instead! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.
@@ -274,7 +274,7 @@ This section is currently only available for the RadioMaster Ranger module.
             !!! Note
                 If your browser cannot resolve this address, chances are MDNS is not set up and working on your computer or network.
 
-            ??? tip "Use the IP Address instead!"
+            ??? tip "Use the IP Address instead! (click/tap to expand)"
                 === "The `arp` Command"
 
                     1. Open up a Command Prompt window on your computer.

--- a/docs/software/updating/wifi-updating.md
+++ b/docs/software/updating/wifi-updating.md
@@ -16,7 +16,7 @@ Put your device in WiFi Updating mode. For TX modules, this is accomplished usin
 
 Connect to the hotspot that the device has created. For Tx modules, this hotspot should show up as **ExpressLRS TX** while for receivers, the hotspot will have a name such as **ExpressLRS RX**. They have the same password: `expresslrs`. 
 
-??? Warning "Updating on Phones"
+??? Warning "Updating on Phones (click/tap to expand)"
     In case your computer does not have wifi capabilities, you can use a wifi capable smartphone as well. Most phones will display a notification after a successfull connection. This is because the phone does not recognize an internet connection. It is recommended to acknowledge this notification because the phone might disconnect again.
 
     On iOS, the WiFi Update Page may open immediately. You can close it via the "Cancel" button on the top right and choose "Use without internet"


### PR DESCRIPTION
Enable RX WiFi step is showing the Enable WiFi option being highlighted.
This PR substitute the image with a proper one.

This PR also tries to make the expandable sections a lot more obvious, especially to the unantiquated.