### PR TITLE
Fix link in first entry to long range 2.4ghz 50mw competition

### DIFF
--- a/docs/info/long-range.md
+++ b/docs/info/long-range.md
@@ -27,7 +27,7 @@ Anyone can add an entry to the table, and entries should include the:
 ### 50mW or less
 | Max Dist. | Freq | Pkt Rate | TX Power | Type | Failsafe at Max Range? | Pilot Handle | Link to DVR |
 | ---- | -------- | -------- | --------- | --------- | ---------------------- | ------------ | ----------- |
-| 31.56km | 2.4G | 50Hz | 50mW | Wing | No | Les Y | [Link] (https://www.youtube.com/watch?v=sK-OAQUwgyU)|
+| 31.56km | 2.4G | 50Hz | 50mW | Wing | No | Les Y | [Link](https://www.youtube.com/watch?v=sK-OAQUwgyU)|
 | 40.6km | 2.4G | 50Hz | 25mW | Wing | No | Shawn U | [Link](https://youtu.be/TmSVSCLTUGI?si=nKfhwG8HgvqX104B) |
 | 19.61km | 2.4G | 50Hz | 25mW | Wing | Yes | Les Y | [Link](https://www.youtube.com/watch?v=VDqrNhLCXE8)|
 | 18.97Km| 2.4G | 150Hz | 50mW | Wing | yes | TitanDynamics | [Link](https://www.youtube.com/watch?v=LPDKBW9XNKM) |


### PR DESCRIPTION
## This PR
- Fixes the link at [this](https://www.expresslrs.org/info/long-range/#50mw-or-less) section, at the end of the first table entry.

## NOTE
This is my first PR, I have used mkdocs extensively but this is my first PR to this repo, so please tell me if I did anything wrong.