### PR TITLE
Add team race docs

### DIFF
--- a/docs/quick-start/transmitters/lua-howto.md
+++ b/docs/quick-start/transmitters/lua-howto.md
@@ -365,6 +365,13 @@ The `Telemetry Power` setting is used to adjust the telemetry transmit power of 
 
 The `Initialization Rate` setting controls the packet rate that the receiver will start checking for the Sync Packet. On boot, the receiver will listen for the Sync Packet starting with the fastest RF Mode or Packet Rate, down to the slowest, then cycles, until it finally Syncs and Binds. Setting this parameter closer or equal to the Packet Rate you've set for the TX module will allow the receiver to Bind or Connect much faster.
 
+### Team Race
+
+Team Racing allows selection between multiple connected models, failsafing all unselected models. See [Team Racing](../../software/teamracing.md)
+
+* `Channel` (default CH11 / AUX7) TeamRace Channel - The channel that is checked on the receiver to determine the currently selected model. Has no effect if the TeamRace Position is set to Disabled.
+* `Position` (default Disabled) TeamRace Position - Which position of the TeamRace Channel activates this model. 6-position switches are supported (1-6) as well as Low/Mid/High for using a 2 or 3-position switch.
+
 ### Loan Model/Return Model
 
 These commands allow the user to Loan/Return the model. For more information, see the [Loan Model](../../software/loan-model.md) guide.

--- a/docs/software/teamracing.md
+++ b/docs/software/teamracing.md
@@ -1,0 +1,45 @@
+---
+template: main.html
+description: TeamRacing allows selection between multiple connected models, failsafing all unselected models.
+---
+
+<img src="https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png">
+
+## What is Team Racing?
+
+Team Racing is a recveiver feature that allows multiple models to be connected to one transmitter at the same time. Each model is assigned to a different switch position and will select that model to control. Any non-selected model is failsafed and will have its telemetry disabled.
+
+The purpose of the receiver selection is to allow a downed model (which is physically unreachable mid-race) to be deactivated and allow the pilot to take control of another model using the same controller. In a default setup, if the pilot plugged in a new model and armed, both models will respond and arm which is incredibly undesirable. This would be used in a Team Race event such as MultiGP Mayhem.
+
+### Formal Definition
+
+Team Racing is defined in this context as:
+
+* 0 or 1 active transmitters with a distinct binding phrase. "One pilot operating their transmitter"
+* Multiple receivers bound to that transmitter's binding phrase, all powered at the same time.
+* Pilot has the ability to direct which receiver is currently "active" including:
+  * Sending channels data and linkstats information to flight controller
+  * Transmitting telemetry to the TX
+  * Updating servo positions
+
+### Team Racing does NOT
+
+* Allow multiple pilots (more than 1 active transmitter) to control a model. There is only one binding phrase and ExpressLRS rule is one active transmitter per binding phrase.
+* Support different packet rates / switch modes per model. All models use the same packet parameters.
+* Encourage pilots to have multiple active models flying at once, e.g. launching a model and putting it into autopilot, then switching to a second model to chase it by effectively failsafing the first via TeamRace switch.
+* Adjust VTX power settings when switching.
+
+## Setup
+
+Two configuration parameters are present in the Receiver Lua (ExpressLRS Lua -> Other Devices -> (select receiver item) -> Team Race). See [ExpressLRS Lua script](../quick-start/transmitters/lua-howto.md#team-race)
+
+* Channel - The channel that is checked to determine the currently selected model.
+* Position - Which position of the TeamRace Channel activates this model.
+
+No flight controller setup is needed. The receiver selection is completely transparent to the flight controller-- the channels will stop updating and it should failsafe as normal. **NOTE** Servos will wait 1s before switching to failsafe positions, which may be longer than normal (LQ dropping to 0 is usually faster than the 1s hard timeout).
+
+Team Racing works in Hybrid and Wide switch mode as well as FullRes packet modes. When the receiver is in a TeamRace Mismatch mode, the LED will display the "Model Mismatch" blink pattern / color. The Lua will not display Model Mismatch, as telemetry will be disabled.
+
+## VTX Control
+
+No VTX Admin / Control is performed when deselecting a model at this time due to the variety of ways a user might configure their VTX to go into Pit Mode: ExpressLRS VTX Admin Pit Switch, Betaflight PitMode mode switch, or USER1/USER2/pinio_box power cut. The user must still configure their method to disable the deselected VTX using the Team Race channel. For CRSF mode serial output, ExpressLRS guarantees at least one packet with the proper deselected channel position will be sent to the flight controller to handle this.

--- a/docs/software/teamracing.md
+++ b/docs/software/teamracing.md
@@ -7,7 +7,7 @@ description: TeamRacing allows selection between multiple connected models, fail
 
 ## What is Team Racing?
 
-Team Racing is a recveiver feature that allows multiple models to be connected to one transmitter at the same time. Each model is assigned to a different switch position and will select that model to control. Any non-selected model is failsafed and will have its telemetry disabled.
+Team Racing is a receiver feature that allows multiple models to be connected to one transmitter at the same time. Each model is assigned to a different switch position and will select that model to control. Any non-selected model is failsafed and will have its telemetry disabled.
 
 The purpose of the receiver selection is to allow a downed model (which is physically unreachable mid-race) to be deactivated and allow the pilot to take control of another model using the same controller. In a default setup, if the pilot plugged in a new model and armed, both models will respond and arm which is incredibly undesirable. This would be used in a Team Race event such as MultiGP Mayhem.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -261,6 +261,7 @@ nav:
           - Model Matching: software/model-config-match.md
           - Dynamic Transmit Power: software/dynamic-transmit-power.md
           - Loan Model: software/loan-model.md
+          - Team Racing: software/teamracing.md
       - Testing:
           - CRC Testing: software/testing/crc-testing.md
           - Unit Testing: software/testing/unit-testing.md


### PR DESCRIPTION
Companion to #2176 for ExpressLRS 3.4, hold until release.
https://github.com/ExpressLRS/ExpressLRS/pull/2176

Unsure if the full Lua item description should go on the team race page or the Lua page. The monster-long Lua page won but I can swap em if it feels better.