### PR TITLE
Fix more broken image links

### DIFF
--- a/docs/hardware/smd-antenna.md
+++ b/docs/hardware/smd-antenna.md
@@ -12,7 +12,7 @@ Have you ever wished you could build a quad without worrying about how to mount 
 If so, the SMD Antenna is for you!  
 
 <figure markdown>
-<img class="center-img" src="../assets/images/IMG_0665.JPG" width="40%">
+<img class="center-img" src="../../assets/images/IMG_0665.png" width="40%">
 <figcaption>SMD Antenna</figcaption>
 </figure>
 
@@ -32,11 +32,11 @@ This perky little fellow is worse at receiving signals than his snaky brothers, 
     The antenna is sort of fragile and can break off or be melted by a stray soldering iron. If this happens, you can save your receiver by soldering a U.FL/IPEX1 connector onto the pads as shown here. Just make sure the center pin has continuity with the filter at the other end of the trace, and no continuity with the ground.  
 
 <figure markdown>
-<img class="center-img" src="../assets/images/IMG_0456.jpg" width="40%">
+<img class="center-img" src="../../assets/images/IMG_0456.jpg" width="40%">
 </figure>
 
 Conversely, the SMD antenna can be soldered to regular U.FL footprints if you're brave.  
 
 <figure markdown>
-<img class="center-img" src="../assets/images/IMG_0380_1.jpg">
+<img class="center-img" src="../../assets/images/IMG_0380_1.jpg">
 </figure>

--- a/docs/hardware/special-targets/diy-tx.md
+++ b/docs/hardware/special-targets/diy-tx.md
@@ -17,7 +17,7 @@ Possibly one of the biggest benefits of using `ExpressLRS` is custom hardware!
 All of the info on this topic can be found [here](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB/2400MHz/TX_SX1280)
 
 <figure markdown>
-<img class="center-img" src="../../assets/images/diytx0.jpg" width=40%>
+<img class="center-img" src="../../../assets/images/diytx0.jpg" width=40%>
 </figure>
 
 ### Custom Super Slim ESP 2.4 GHz TX (for lite module bay)
@@ -25,7 +25,7 @@ All of the info on this topic can be found [here](https://github.com/ExpressLRS/
 The super slim is an evolution of the slim. It uses the same base hardware as the JR size one. It's the same size as an R9M Lite, and fits in all handsets with a lite module bay such as the X-Lite, X9 Lite, and Tango 2 (with the proper adapter). The rest of the info can be found [here](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB/2400MHz/TX_SX1280_Super_Slim)
 
 <figure markdown>
-<img class="center-img" src="../../assets/images/diytx1.jpg" width=40%>
+<img class="center-img" src="../../../assets/images/diytx1.jpg" width=40%>
 </figure>
 
 ### Custom 900 MHz TX (not built anymore)

--- a/docs/hardware/special-targets/nuclear-hardware.md
+++ b/docs/hardware/special-targets/nuclear-hardware.md
@@ -17,7 +17,7 @@ The Nuclear RX is designed to be as small as possible, using the same software t
 - Up to 500Hz packet rate  
 
 <figure markdown>
-<img class="center-img" src="../../assets/images/IMG_0665.jpg" width="40%">
+<img class="center-img" src="../../../assets/images/IMG_0665.jpg" width="40%">
 </figure>
 
 When you get your Nuclear RX, it will likely be on the latest release firmware. You'll probably have to update it to work with your TX. To update, follow the steps in the [WiFi updating](../../software/updating/wifi-updating.md) page. Alternatively, you can use [betaflight passthrough](../../software/updating/betaflight-passthrough.md) should work, but the boot jumper must be bridged while applying power to the RX.
@@ -34,7 +34,7 @@ When building, use one of the `DIY_2400_RX_ESP8285_SX1280_via_X` targets. To use
 If for some reason the RX needs to be in boot mode, bridge the jumpers as shown here:
 
 <figure markdown>
-<img class="center-img" src="../../assets/images/Capture.png" width="40%">
+<img class="center-img" src="../../../assets/images/Capture.png" width="40%">
 </figure>
 
 ## Nuclear TX

--- a/docs/software/dynamic-transmit-power.md
+++ b/docs/software/dynamic-transmit-power.md
@@ -83,23 +83,23 @@ On startup, the output power will be set to the lowest possible value. If teleme
 
 ### OSD Power Display
 
-To see the current output power on your FPV OSD, enable the `TX uplink power` OSD element. Uplink power is not available if `Switch Mode` is set to `Hybrid`, or older Betaflight (<4.3.0) and iNav (<2.6.0) versions. This value updates 8x more quickly in fullres packet modes.
+To see the current output power on your FPV OSD, enable the `TX Uplink Power` OSD element and set `Switch Mode` to `Wide` in the ELRS lua. `TX Uplink Power` is not available if `Switch Mode` is set to `Hybrid`, or on older Betaflight (<4.3.0) and iNav (<2.6.0) versions. 
 
 ### EdgeTX / OpenTX Power Readout
 
-Alternatively, a handset special function can be used to generate an audio notification when changes in the power level changes.
+Alternatively, a handset special function can be used to generate an audio notification when the TX power level changes.
 
 * Set a logical switch to `|Δ|>x` / `TPWR` / `1mW` as shown in L04 below. The logical switch triggers when the power changes by at least 1mW.
 
 <figure markdown>
-![OpenTX logical switch page, L04 is set to absolute delta equal or larger than x, TPWR, 1mW](../assets/imagesIMG_9220.JPG)
+![OpenTX logical switch page, L04 is set to absolute delta equal or larger than x, TPWR, 1mW](../../assets/images/IMG_9220.png)
 </figure>
 
 * For a readout when the power changes, set a special function triggered from the logical switch, and assign `Play Value` / `TPWR` / `1x` (SF10 in the picture). If instead you'd prefer the power to be read out periodically, choose a switch to enable the special function, and assign `Play Value` / `TPWR` / (SF11 in the picture, with 10s interval).
 
 <figure markdown>
-![OpenTX Special function page, SF10 is set to L04, Play Value, TPWR, 1x. SF11 is set to SB1 down, Play Value, TPWR, 10s](../assets/images/IMG_9221.JPG)
+![OpenTX Special function page, SF10 is set to L04, Play Value, TPWR, 1x. SF11 is set to SB1 down, Play Value, TPWR, 10s](../../assets/images/IMG_9221.png)
 </figure>
 
 !!! note "Note"
-    OpenTX has no value for 50mW in the CRSF Telemetry protocol and instead will be read as 0mW. EdgeTX starting 2.5.0 have the proper 50mW readout.
+    OpenTX has no value for 50mW in the CRSF Telemetry protocol and instead will be read as 0mW. EdgeTX versions 2.5.0 and newer have the proper 50mW readout.

--- a/docs/software/toolchain-install.md
+++ b/docs/software/toolchain-install.md
@@ -39,7 +39,7 @@ We recommend using VSCode's built-in Git client, as it requires the least 3rd pa
 * Enter `Git: Clone` 
 
 <figure markdown>
-<img class="center-img" src="../assets/images/gitclone.png" width=100%>
+<img class="center-img" src="../../assets/images/gitclone.png" width=100%>
 </figure>
 
 * Click that! 👈 
@@ -50,11 +50,11 @@ We recommend using VSCode's built-in Git client, as it requires the least 3rd pa
 Before we can do any building, you need to select a release build of ELRS. For example, release [0.1.0-RC1](https://github.com/AlessandroAU/ExpressLRS/releases/tag/0.1.0-RC1). In Visual Studio Code select that tag. The location of the selector is shown below. 🖱️ 
 
 <figure markdown>
-<img class="center-img" src="../assets/images/src.png" width=100%>
+<img class="center-img" src="../../assets/images/src.png" width=100%>
 </figure>
 
 <figure markdown>
-<img class="center-img" src="../assets/images/selector.png" width=100%>
+<img class="center-img" src="../../assets/images/selector.png" width=100%>
 </figure>
 
 Click the selector, and then type in the name of the tag, in this case `0.1.0-RC1`. 


### PR DESCRIPTION
A number of image links were broken due to improper relative URLs or file extensions.  Also fixes a few typos on the Dynamic Power page.