### PR TITLE
Update docs to include backpack master/wifi update notes

### DIFF
--- a/docs/software/mavlink.md
+++ b/docs/software/mavlink.md
@@ -26,7 +26,9 @@ To start using MAVLink, you just need one ESP ELRS transmitter, and one ESP ELRS
 
 ## Flashing and Configuring the MAVLink branch
 
-1. At the top of the ExpressLRS configurator, select "GIT BRANCH"
+1. From the "Settings" tab on the left hand side, make sure "Expert Mode" is selected.
+
+1. Back in the "Configurator" tab, at the top, select "GIT BRANCH"
 
 1. Select the `master` branch, and flash it to both the RX and TX
 
@@ -47,6 +49,8 @@ To start using MAVLink, you just need one ESP ELRS transmitter, and one ESP ELRS
     1. Configure `SERIALx_PROTOCOL=2`, `SERIALx_BAUD=460`, and `RSSI_TYPE=5`
     1. Connect the TX module to the computer running the Ground Control Station via a USB cable
     1. Select the COM port on the GCS, and connect using `460800` baud
+    1. If connecting from Backpack WiFi to Mission Planner, select "UDP" and and ensure the port is 14550, and connect. (This step requires Backpack to be on Master branch)
+    - Some radios are not able to connect on USB for hardware related reasons, like the Radiomaster Pocket. Those radios will require WiFi to be used instead of USB. Instructions are below.
 
 === "PX4"
     For the below steps, when a UART connection is mentioned, it will be written as `SER_TELx`. Replace `x` with the UART number you are using.
@@ -67,6 +71,17 @@ To start using MAVLink, you just need one ESP ELRS transmitter, and one ESP ELRS
 === "Betaflight"
 
     Betaflight contains an incomplete implementation of the MAVLink protocol standard (lacking RADIO_STATUS flow control). This causes an Betaflight aircraft to saturate the bandwidth of a telemetry link using soft flow control, and renders it unusable, ergo breaking support with ExpressLRS MAVLink.
+
+
+## Enabling WiFi connectivity from ELRS Backpack
+
+To enable WiFi connection of the backpack to the GCS you will also need to update the ELRS Backpack to the master branch. This will be very similar to how you flashed the master branch onto the TX & RX. To do this:
+
+1. On the left hand side of the ELRS Configurator, select "Backpack"
+
+2. Select Git branch, select the `master` branch, and flash it onto the backpack.
+
+3. Once the backpack is flashed, either connect to the backpacks network or connect to the network the backpack is flashed onto. You can now connect from the GCS.
 
 
 ## Implementation Details


### PR DESCRIPTION
This page was extremely useful and carried me through the installation process. My radio however wasnt able to use USB to connect to the GCS - I added a section in and also added some clarification about which of the readers would especially need to follow these instructions.  