### PR TITLE
Update Docs to include BetaFPV AIO reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -237,7 +237,7 @@ nav:
           - Typical Updating Steps: quick-start/receivers/updating.md
           - Updating Receivers:
               - Axisflying Thor: quick-start/receivers/axisflying-thor.md
-              - BetaFPV Lite & Nano 2.4GHz: quick-start/receivers/betafpv2400.md
+              - BetaFPV Lite/Nano/AIO 2.4GHz: quick-start/receivers/betafpv2400.md
               - BetaFPV Nano 900MHz: quick-start/receivers/betafpv900.md
               - BetaFPV SuperD 2.4GHz: quick-start/receivers/betafpv-superd.md
               - BetaFPV SuperD 900MHz: quick-start/receivers/betafpv-superd900.md


### PR DESCRIPTION
Make it clear that receiver flashing guide applies to BetaFPV AIO receivers also