### PR TITLE
Added missing information on how to set Model ID on SPI based receivers

### DIFF
--- a/docs/hardware/spi-receivers.md
+++ b/docs/hardware/spi-receivers.md
@@ -100,6 +100,12 @@ UID Bytes
 ```
 ```
 
+### Model ID
+
+In order to set or retrieve current Model ID through Betaflight you need to use CLI:
+- Set new Model ID: `set expresslrs_model_id = N`
+- Get current Model ID: `get expresslrs_model_id`
+
 #### Setting Binding Phrase
 Go to Betaflight CLI and enter the following commands.
 ```


### PR DESCRIPTION
I couldn't find any information in the official documentation on how to set the Model ID for SPI receivers (relevant for Mobula 6/7/etc.). 

One of the few references that helped me solve the issue was in an old PR.

I think it would be useful to add this information to the documentation.