### PR TITLE
Notice for Ending of Support for STM32-based Hardware

### DIFF
--- a/docs/quick-start/receivers/flash2400.md
+++ b/docs/quick-start/receivers/flash2400.md
@@ -605,6 +605,8 @@ Some of the following procedures will not go through, particularly the via Passt
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 === "via Passthrough"
 
     <figure markdown>

--- a/docs/quick-start/receivers/flash2400.md
+++ b/docs/quick-start/receivers/flash2400.md
@@ -602,6 +602,9 @@ Some of the following procedures will not go through, particularly the via Passt
 
 ## Updating your Receiver Firmware (STM-based)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 === "via Passthrough"
 
     <figure markdown>

--- a/docs/quick-start/receivers/ghost2400.md
+++ b/docs/quick-start/receivers/ghost2400.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 ## Flashing/Updating your Receiver Firmware 
 
 === "via STLink"

--- a/docs/quick-start/receivers/ghost2400.md
+++ b/docs/quick-start/receivers/ghost2400.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 ## Flashing/Updating your Receiver Firmware 
 
 === "via STLink"

--- a/docs/quick-start/receivers/hmes900.md
+++ b/docs/quick-start/receivers/hmes900.md
@@ -593,6 +593,8 @@ Some of the following procedures will not go through, particularly the via Passt
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 === "via Passthrough"
 
     <figure markdown>

--- a/docs/quick-start/receivers/hmes900.md
+++ b/docs/quick-start/receivers/hmes900.md
@@ -590,6 +590,9 @@ Some of the following procedures will not go through, particularly the via Passt
 
 ## Updating your Receiver Firmware (ES915RX/ES868RX)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 === "via Passthrough"
 
     <figure markdown>

--- a/docs/quick-start/receivers/hmpp2400.md
+++ b/docs/quick-start/receivers/hmpp2400.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 ## Wiring up your receiver
 
 <figure markdown>

--- a/docs/quick-start/receivers/hmpp2400.md
+++ b/docs/quick-start/receivers/hmpp2400.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 ## Wiring up your receiver
 
 <figure markdown>

--- a/docs/quick-start/receivers/jumper900.md
+++ b/docs/quick-start/receivers/jumper900.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 ## Flashing/Updating your Receiver Firmware
 
 === "via STLink"

--- a/docs/quick-start/receivers/jumper900.md
+++ b/docs/quick-start/receivers/jumper900.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 ## Flashing/Updating your Receiver Firmware
 
 === "via STLink"

--- a/docs/quick-start/receivers/r9.md
+++ b/docs/quick-start/receivers/r9.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 ## Bootloaders
 
 The R9Mini/R9MM, R9MX and R9Slim+ require ExpressLRS Bootloaders to be flashed before the ExpressLRS firmware. The R9Slim doesn't have a bootloader and first time flash requires STLink.

--- a/docs/quick-start/receivers/r9.md
+++ b/docs/quick-start/receivers/r9.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 ## Bootloaders
 
 The R9Mini/R9MM, R9MX and R9Slim+ require ExpressLRS Bootloaders to be flashed before the ExpressLRS firmware. The R9Slim doesn't have a bootloader and first time flash requires STLink.

--- a/docs/quick-start/receivers/siyiFRmini.md
+++ b/docs/quick-start/receivers/siyiFRmini.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 !!! note "Note"
     This is only guaranteed to work on the v3.0 of the receiver.
 

--- a/docs/quick-start/receivers/siyiFRmini.md
+++ b/docs/quick-start/receivers/siyiFRmini.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 !!! note "Note"
     This is only guaranteed to work on the v3.0 of the receiver.
 

--- a/docs/quick-start/receivers/voyager900.md
+++ b/docs/quick-start/receivers/voyager900.md
@@ -579,6 +579,9 @@ Some of the following procedures will not go through, particularly the via Passt
 
 ## Updating your Receiver Firmware (STM-based)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 === "via Passthrough"
 
     <figure markdown>

--- a/docs/quick-start/receivers/voyager900.md
+++ b/docs/quick-start/receivers/voyager900.md
@@ -582,6 +582,8 @@ Some of the following procedures will not go through, particularly the via Passt
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 === "via Passthrough"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/es900tx.md
+++ b/docs/quick-start/transmitters/es900tx.md
@@ -392,6 +392,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 === "via Stock_BL"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/es900tx.md
+++ b/docs/quick-start/transmitters/es900tx.md
@@ -389,6 +389,9 @@ template: main.html
 
 ## Flashing/Updating the ES915TX/ES868TX Firmware
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 === "via Stock_BL"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/flash2400.md
+++ b/docs/quick-start/transmitters/flash2400.md
@@ -395,6 +395,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 === "via Stock_BL"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/flash2400.md
+++ b/docs/quick-start/transmitters/flash2400.md
@@ -392,6 +392,9 @@ template: main.html
 
 ## Flashing/Updating the Flash Non-OLED Firmware
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 === "via Stock_BL"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/frsky-r9modules.md
+++ b/docs/quick-start/transmitters/frsky-r9modules.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 !!! warning
     The R9M Lite Pro **can not** be flashed via OpenTX or EdgeTX (Stock_BL method), and therefore requires an STLink v2 to flash. See the guide [below](#via-stlink)
 

--- a/docs/quick-start/transmitters/frsky-r9modules.md
+++ b/docs/quick-start/transmitters/frsky-r9modules.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 !!! warning
     The R9M Lite Pro **can not** be flashed via OpenTX or EdgeTX (Stock_BL method), and therefore requires an STLink v2 to flash. See the guide [below](#via-stlink)
 

--- a/docs/quick-start/transmitters/ghost2400.md
+++ b/docs/quick-start/transmitters/ghost2400.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 ## Flashing/Updating TX Module Firmware
 
 === "via STLink"

--- a/docs/quick-start/transmitters/ghost2400.md
+++ b/docs/quick-start/transmitters/ghost2400.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 ## Flashing/Updating TX Module Firmware
 
 === "via STLink"

--- a/docs/quick-start/transmitters/siyifm30.md
+++ b/docs/quick-start/transmitters/siyifm30.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 ## FM30
 
 ### Flashing via STLink

--- a/docs/quick-start/transmitters/siyifm30.md
+++ b/docs/quick-start/transmitters/siyifm30.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 ## FM30
 
 ### Flashing via STLink

--- a/docs/quick-start/transmitters/voyager900.md
+++ b/docs/quick-start/transmitters/voyager900.md
@@ -4,6 +4,9 @@ template: main.html
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)
 
+!!! warning "Attention"
+    ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
+
 ## Flashing/Updating the TX Module Firmware
 
 === "via Stock_BL"

--- a/docs/quick-start/transmitters/voyager900.md
+++ b/docs/quick-start/transmitters/voyager900.md
@@ -7,6 +7,8 @@ template: main.html
 !!! warning "Attention"
     ExpressLRS 3.5.x will be the last version to support STM32-based hardware. This includes the Happymodel PP, ES915 Tx and Rx, early NamimnoRC Flash and Voyager, FrSky R9, SIYI and ImmersionRC hardware.
 
+    The STM32 platform's limited compute resources and feature gaps (WiFi, Bluetooth, Backpacks) made for an inferior version of ExpressLRS that necessitated disproportionate maintenance burden for the Dev Team.
+
 ## Flashing/Updating the TX Module Firmware
 
 === "via Stock_BL"


### PR DESCRIPTION
ExpressLRS 3.5.x is the last version that the STM32-based devices will be supported. 

This PR adds the Warning in the STM32-based Hardware's respective pages.