### PR TITLE
Fix: Broken/legacy GitHub repo urls

### DIFF
--- a/docs/hardware/special-targets/diy-rx.md
+++ b/docs/hardware/special-targets/diy-rx.md
@@ -18,14 +18,14 @@ Possibly one of the biggest benefits of using `ExpressLRS` is custom hardware!
 <figcaption markdown>[20x20 RX](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB/2400MHz/RX_20x20)</figcaption>
 </figure>
 
-- 20x20 footprint and uses 0805 size SMD components. SMD components have been positioned on the PCB in a soldering iron friendly way. 🚸 
+- 20x20 footprint and uses 0805 size SMD components. SMD components have been positioned on the PCB in a soldering iron friendly way. 🚸
 
 <figure markdown>
 ![RX Nano](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/PCB/2400MHz/RX_Nano/img/front.jpg){ width=40% }
 <figcaption markdown>[ELRS Nano](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB/2400MHz/RX_Nano)</figcaption>
 </figure>
 
-- The `ELRS Nano` RX is 18mm x 11mm and uses the same pinout as the `Crossfire Nano` RX. This allows for direct mounting to compatible flight controllers. ⚠️ This PCB uses 0402 SMD components and will require a hot air rework station and probably a microscope. 🔬 
+- The `ELRS Nano` RX is 18mm x 11mm and uses the same pinout as the `Crossfire Nano` RX. This allows for direct mounting to compatible flight controllers. ⚠️ This PCB uses 0402 SMD components and will require a hot air rework station and probably a microscope. 🔬
 
 ### Custom ESP 900 MHz RX
 
@@ -37,8 +37,8 @@ Possibly one of the biggest benefits of using `ExpressLRS` is custom hardware!
 
 * Uses the `ESP-01F` for WiFi and a `RFM95` for our business 🕴️
 * Requires ordering PCBs from Gerber files, a regulator chip, a few passives, a `ESP-01F` and a `RFM95` (915/868MHz)
-* Multiple RX PCB designs [are available](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB) ✅    
-    * [`20x20 RX`](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB/900MHz/RX_20x20_0603_SMD) 
+* Multiple RX PCB designs [are available](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB) ✅
+    * [`20x20 RX`](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB/900MHz/RX_20x20_0603_SMD)
         * discrete SMD antenna for Wifi and RF directly soldered to PCB
         * Target DIY_900_RX_ESP8285_SX127x_via_UART
     * [`20x20 RX 0805`](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB/900MHz/RX_20x20_0805_SMD) - easier to build due to bigger SMD parts. PCB antenna for Wifi and `u.fl` connector for RF
@@ -50,7 +50,7 @@ Possibly one of the biggest benefits of using `ExpressLRS` is custom hardware!
 #### Before you start
 
 * The steps for building are in each individual [`README.md`](https://github.com/ExpressLRS/ExpressLRS-Hardware/tree/master/PCB) for the RX of your choice
-* If you are using an `ESP-12F` instead of `ESP-01F` it is recommended to follow [this tutorial](https://github.com/AlessandroAU/ExpressLRS/wiki/ESP-Backpack-Addon#board-esp12f) but use the appropriate RX target 🧑‍🏫 
+* If you are using an `ESP-12F` instead of `ESP-01F` it is recommended to follow [this tutorial](https://github.com/ExpressLRS/ExpressLRS/wiki/ESP-Backpack-Addon#board-esp12f) but use the appropriate RX target 🧑‍🏫
 
 #### Get it flashed
 

--- a/docs/software/obsolete-defines.md
+++ b/docs/software/obsolete-defines.md
@@ -78,7 +78,7 @@ Enable advanced telemetry support. This option must be enabled on both **TX** an
 * FLIGHT_MODE
 * MSP_RESP
 
-!!! note 
+!!! note
     Increase the telemetry rate with the ExpressLRS Lua script. Increase the rate until the sensor lost warnings go away. It is normal to set it up to 1:16 with 200 Hz refresh rate.
 
 !!! note
@@ -89,7 +89,7 @@ Enable advanced telemetry support. This option must be enabled on both **TX** an
 ```
 -DUSE_500HZ
 ```
-This enables 500Hz mode for 2.4 GHz RXes and TXes. The drawback is that you have to give up 25Hz mode to add 500Hz mode. It requires [OpenTX 2.3.12 or Newer](https://www.open-tx.org/2021/06/14/opentx-2.3.12), [EdgeTX](https://github.com/EdgeTX/edgetx) or a Radio firmware that has CRSFShot or Mixer Sync. 
+This enables 500Hz mode for 2.4 GHz RXes and TXes. The drawback is that you have to give up 25Hz mode to add 500Hz mode. It requires [OpenTX 2.3.12 or Newer](https://www.open-tx.org/2021/06/14/opentx-2.3.12), [EdgeTX](https://github.com/EdgeTX/edgetx) or a Radio firmware that has CRSFShot or Mixer Sync.
 
 {++**REMOVED** 1.0.0-RC9, this option is now always enabled and in turn, 25Hz has been dropped/removed.++}
 
@@ -108,7 +108,7 @@ An option that adds faster initial syncing, by changing how long the receiver wa
 {++**REMOVED** 1.0.0-RC2 initial sync replaced with a full FHSS period wait++}
 
 ````
-#-DR9M_UNLOCK_HIGHER_POWER 
+#-DR9M_UNLOCK_HIGHER_POWER
 ````
 {++**REMOVED** 1.0.0-RC1 replaced with generic `-DUNLOCK_HIGHER_POWER`++}
 
@@ -124,7 +124,7 @@ NB This feature assumes that a low value of the arm switch is disarmed, and a hi
 ```
 #-DLOCK_ON_50HZ
 ```
-`LOCK_ON_50HZ` locks the RX at `50Hz` mode from the power-up. (Only recommended for long range, and partly redundant with the previous feature.) Merged in [Pull 143](https://github.com/AlessandroAU/ExpressLRS/pull/143)
+`LOCK_ON_50HZ` locks the RX at `50Hz` mode from the power-up. (Only recommended for long range, and partly redundant with the previous feature.) Merged in [Pull 143](https://github.com/ExpressLRS/ExpressLRS/pull/143)
 
 {++**REMOVED** 1.0.0-RC1 not sure why this was removed++}
 

--- a/docs/software/toolchain-install.md
+++ b/docs/software/toolchain-install.md
@@ -48,7 +48,7 @@ We recommend using VSCode's built-in Git client, as it requires the least 3rd pa
 * Choose a folder for ExpressLRS. 📂
 
 ### Selecting the Latest Release
-Before we can do any building, you need to select a release build of ELRS. For example, release [0.1.0-RC1](https://github.com/AlessandroAU/ExpressLRS/releases/tag/0.1.0-RC1). In Visual Studio Code select that tag. The location of the selector is shown below. 🖱️
+Before we can do any building, you need to select a release build of ELRS. For example, release [0.1.0-RC1](https://github.com/ExpressLRS/ExpressLRS/releases/tag/0.1.0-RC1). In Visual Studio Code select that tag. The location of the selector is shown below. 🖱️
 
 <figure markdown>
 ![latest release](../assets/images/src.png)
@@ -62,15 +62,15 @@ Click the selector, and then type in the name of the tag, in this case `0.1.0-RC
 
 ### PlatformIO Building
 
-Once you had the time of your life setting up your toolchain 🧰 you are **ready** to Flash ⚡ ExpressLRS to supported [hardware](https://github.com/AlessandroAU/ExpressLRS/wiki/Supported-Off-The-Shelf-Hardware).
+Once you had the time of your life setting up your toolchain 🧰 you are **ready** to Flash ⚡ ExpressLRS to supported [hardware](https://github.com/ExpressLRS/ExpressLRS/wiki/Supported-Off-The-Shelf-Hardware).
 
 ### Building Targets using PlatformIO
 
 1. 📂 When you first launch `Visual Studio Code`, you should see the `PlatformIO Home Page` in a tab.
 Click the `Open Project` button. Navigate to the `ExpressLRS` repo directory. Navigate into the `src` folder (i.e. `./ExpressLRS/src/`). Finally, press the `Open` button.
-2. ✏️ Edit the file [`./src/user_defines.txt`](https://github.com/AlessandroAU/ExpressLRS/blob/master/src/user_defines.txt) to define user specific variables. 😈 Please make sure you edit the file according to __your__ needs!
+2. ✏️ Edit the file [`./src/user_defines.txt`](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/user_defines.txt) to define user specific variables. 😈 Please make sure you edit the file according to __your__ needs!
 3. 📊 In the toolbar on the left, click the PlatformIO icon, which will show the list of tasks. Now, select Project Tasks, expand your desired target and select Build/Upload (depending on the method). You should see the result in the terminal.
-4. 🙃 If something went wrong - please check the `Terminal`, too. It will contain at least a hint of what the issue is. Please ask the [community](https://github.com/AlessandroAU/ExpressLRS/wiki#community) for further help🧑‍🔧!
+4. 🙃 If something went wrong - please check the `Terminal`, too. It will contain at least a hint of what the issue is. Please ask the [community](https://github.com/ExpressLRS/ExpressLRS/wiki#community) for further help🧑‍🔧!
 
 ## Updating your Local Repo
 

--- a/docs/software/toolchain-install.md
+++ b/docs/software/toolchain-install.md
@@ -5,19 +5,19 @@ template: main.html
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)
 
 
-!!! note "Note" 
+!!! note "Note"
     The following section is intended for advanced users who intend to dabble with the source code directly.
 
 ## Toolchain Setup (Advanced)
 
-`ExpressLRS` is written in C++ using the Arduino framework. 
+`ExpressLRS` is written in C++ using the Arduino framework.
 
  * Rather than using the Arduino IDE (which let's face it, 🗿 is pretty clunky), we use [PlatformIO](https://platformio.org/)
  * To ease the use of `pio` we recommend using the [extension ](https://platformio.org/install/ide?install=vscode)  for `Visual Studio Code`
 
 ### PlatformIO
 
-1. 🔽 **Download** a copy of [VSCode](https://code.visualstudio.com/) for your computer 
+1. 🔽 **Download** a copy of [VSCode](https://code.visualstudio.com/) for your computer
 2. 📂 **Open** VSCode, and click on the "__Extensions__" icon in the toolbar on the right (see [Managing Extensions](https://code.visualstudio.com/docs/editor/extension-gallery) 📘)
 3. 🔎 In the search box, enter `platformio`, and **install** the **extension** (see [the `pio install` documentation](https://platformio.org/install/ide?install=vscode) 📚)
 
@@ -29,7 +29,7 @@ We recommend using VSCode's built-in Git client, as it requires the least 3rd pa
 2. Install `git`, click **yes** to the default options (there are a **LOT** 💯)
 
 !!! important
-    Make sure you select this option during installation, it adds git to PATH which is necessary for VSCode cloning (the next step). 
+    Make sure you select this option during installation, it adds git to PATH which is necessary for VSCode cloning (the next step).
 
 <figure markdown>
 ![git install](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/git_path_option.png)
@@ -37,18 +37,18 @@ We recommend using VSCode's built-in Git client, as it requires the least 3rd pa
 
 ### Cloning the Repo
 * In VSCode open the `command palette` (using `Cmd+Shift+P` on MacOS or `Ctrl+Shift+P` on Windows)
-* Enter `Git: Clone` 
+* Enter `Git: Clone`
 
 <figure markdown>
 ![clone repo](../assets/images/gitclone.png)
 </figure>
 
-* Click that! 👈 
-* Then, enter ExpressLRS Repo URL -> `https://github.com/ExpressLRS/ExpressLRS.git` 💻 
-* Choose a folder for ExpressLRS. 📂 
+* Click that! 👈
+* Then, enter ExpressLRS Repo URL -> `https://github.com/ExpressLRS/ExpressLRS.git` 💻
+* Choose a folder for ExpressLRS. 📂
 
 ### Selecting the Latest Release
-Before we can do any building, you need to select a release build of ELRS. For example, release [0.1.0-RC1](https://github.com/AlessandroAU/ExpressLRS/releases/tag/0.1.0-RC1). In Visual Studio Code select that tag. The location of the selector is shown below. 🖱️ 
+Before we can do any building, you need to select a release build of ELRS. For example, release [0.1.0-RC1](https://github.com/AlessandroAU/ExpressLRS/releases/tag/0.1.0-RC1). In Visual Studio Code select that tag. The location of the selector is shown below. 🖱️
 
 <figure markdown>
 ![latest release](../assets/images/src.png)
@@ -58,7 +58,7 @@ Before we can do any building, you need to select a release build of ELRS. For e
 ![branch selecttion](../assets/images/selector.png)
 </figure>
 
-Click the selector, and then type in the name of the tag, in this case `0.1.0-RC1`. 
+Click the selector, and then type in the name of the tag, in this case `0.1.0-RC1`.
 
 ### PlatformIO Building
 
@@ -68,7 +68,7 @@ Once you had the time of your life setting up your toolchain 🧰 you are **read
 
 1. 📂 When you first launch `Visual Studio Code`, you should see the `PlatformIO Home Page` in a tab.
 Click the `Open Project` button. Navigate to the `ExpressLRS` repo directory. Navigate into the `src` folder (i.e. `./ExpressLRS/src/`). Finally, press the `Open` button.
-2. ✏️ Edit the file [`./src/user_defines.txt`](https://github.com/AlessandroAU/ExpressLRS/blob/master-dev/src/user_defines.txt) to define user specific variables. 😈 Please make sure you edit the file according to __your__ needs! 
+2. ✏️ Edit the file [`./src/user_defines.txt`](https://github.com/AlessandroAU/ExpressLRS/blob/master/src/user_defines.txt) to define user specific variables. 😈 Please make sure you edit the file according to __your__ needs!
 3. 📊 In the toolbar on the left, click the PlatformIO icon, which will show the list of tasks. Now, select Project Tasks, expand your desired target and select Build/Upload (depending on the method). You should see the result in the terminal.
 4. 🙃 If something went wrong - please check the `Terminal`, too. It will contain at least a hint of what the issue is. Please ask the [community](https://github.com/AlessandroAU/ExpressLRS/wiki#community) for further help🧑‍🔧!
 
@@ -136,7 +136,7 @@ Note: the `!` flag is called the removal flag. It removes other flags that compl
 
 ## Toolchain Setup (Advanced) for Linux Users
 
-!!! note "Note" 
+!!! note "Note"
     These instructions are meant as a quick start guide for those who develop on Linux.
     Typically developers on Linux don't need much of an explanation and just look for the right commands for the toolchain.
     That's what this guide will provide, without any nudging to use Microsoft VSCode IDE.

--- a/docs/software/user-defines.md
+++ b/docs/software/user-defines.md
@@ -5,7 +5,7 @@ description: User Defines are firmware flags akin to the Firmware Options. You c
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)
 
-With more features being added consistently, [`./src/user_defines.txt`](https://github.com/AlessandroAU/ExpressLRS/blob/master/src/user_defines.txt) has gotten complicated 🤷‍♂️. So we will break it down! 🔨 
+With more features being added consistently, [`./src/user_defines.txt`](https://github.com/ExpressLRS/ExpressLRS/blob/master/src/user_defines.txt) has gotten complicated 🤷‍♂️. So we will break it down! 🔨
 
 !!! info
 
@@ -22,7 +22,7 @@ With more features being added consistently, [`./src/user_defines.txt`](https://
 MY_BINDING_PHRASE="default ExpressLRS binding phrase"
 ```
 !!! Important
-    This step is simple but **important**. Both the TX and RX NEED to have the same binding phrase or **ExpressLRS WILL NOT WORK**. Anyone using the same binding phrase as you will be able to control your model, so be unique. Set something memorable, and limit to alphanumeric phrases conforming to the Latin alphabet<sup>*</sup>. 
+    This step is simple but **important**. Both the TX and RX NEED to have the same binding phrase or **ExpressLRS WILL NOT WORK**. Anyone using the same binding phrase as you will be able to control your model, so be unique. Set something memorable, and limit to alphanumeric phrases conforming to the Latin alphabet<sup>*</sup>.
 
 Receivers flashed with firmware builds that do not have binding phrases enabled will support and require the traditional binding method. 📜 For ESP/ESP32 hardware, this value can also be changed through the WebUI.
 
@@ -40,7 +40,7 @@ Regulatory_Domain_EU_433
 Regulatory_Domain_FCC_915
 Regulatory_Domain_ISM_2400
 ```
-This is a relatively simple one - enable whatever regulatory domain you are in. `EU 868` 🇪🇺  is compliant to the frequency but **is not** LBT compliant 👂 . Every other band is near compliant 👿  but may not be fully compliant for your regulatory domain. 
+This is a relatively simple one - enable whatever regulatory domain you are in. `EU 868` 🇪🇺  is compliant to the frequency but **is not** LBT compliant 👂 . Every other band is near compliant 👿  but may not be fully compliant for your regulatory domain.
 
 ```
 TLM_REPORT_INTERVAL_MS=240LU
@@ -50,7 +50,7 @@ The TX module sends the LinkStats telemetry to the OpenTX frequently to let the 
 ## Output Power Limit
 
 ````
-UNLOCK_HIGHER_POWER 
+UNLOCK_HIGHER_POWER
 ````
 By default the max power of the hardware is limited to what it can safely output without extra cooling. Some hardware supports increasing the power by enabling the following option. Check the [supported hardware](../hardware/hardware-selection.md) page to see if this is available and what cooling modifications can be made. By enabling this, you are risking permanent damage to your hardware, sometimes even when you add extra cooling. For example, R9M modules will burn out without cooling.
 
@@ -66,7 +66,7 @@ When cycling through the rates, the RX starts with the fastest packet rate and w
 ```
 FAN_MIN_RUNTIME=30
 ```
-For TX devices with fans, FAN_MIN_RUNTIME keeps the fan running even after the power level has dropped below the configured Fan Threshold. This prevents the fan from turning on and off every few seconds if the power level is constantly changing. The default is 30 seconds if not defined, the value can be 0-254. There is always a short delay before the fan is activated, which can not be disabled. 
+For TX devices with fans, FAN_MIN_RUNTIME keeps the fan running even after the power level has dropped below the configured Fan Threshold. This prevents the fan from turning on and off every few seconds if the power level is constantly changing. The default is 30 seconds if not defined, the value can be 0-254. There is always a short delay before the fan is activated, which can not be disabled.
 
 ## Compatibility Options
 
@@ -114,7 +114,7 @@ MY_STARTUP_MELODY="<music string>|<bpm>|<semitone offset>" -or-
 MY_STARTUP_MELODY="<rtttl string>"
 ```
 For TXes like the R9M, this sets if the TX only beeps one-time **versus** playing a startup song. Currently, it is set to play the startup song 🎼 , but if you don't prefer it, uncomment this to turn it off. ✖️
- 
+
 For all your customization needs, use `DMY_STARTUP_MELODY` to define your own startup melody using the BLHeli32 or RTTTL syntax. For BLHeli32, the parameters `music string` and `bpm` are required, whereas `semitone offset` is optional to transpose the entire melody up or down by the defined amount of semitones.
 
 For example, BLHeli32 melodies are available on [Rox Wolf's youtube channel](https://www.youtube.com/playlist?list=PL_O0XT_1mZinetucKyuBUvkju8P7DEg-v), some experimentation may be required though. :musical_note: To write your own melody, **[this (Sheet Music 101)](https://github.com/nseidle/AxelF_DoorBell/wiki/How-to-convert-sheet-music-into-an-Arduino-Sketch)** and **[this (BLHeli Piano)](https://dra6n.github.io/blhelikeyboard.github.io/)** are useful resources.


### PR DESCRIPTION
- Fixed broken link to `https://github.com/ExpressLRS/ExpressLRS/blob/master/src/user_defines.txt` due to incorrect branch name.
- Replaced all links to `https://github.com/AlessandroAU/ExpressLRS/...` with `https://github.com/ExpressLRS/ExpressLRS/...` to be consistent with other documents
- Trimmed trailing whitespace of affected documents.