### PR TITLE
Rephrase wording of ## Model Configuration paragraph to make example less ambiguous

### DIFF
--- a/docs/software/model-config-match.md
+++ b/docs/software/model-config-match.md
@@ -7,7 +7,13 @@ description: ExpressLRS can retain a per-Model configuration eliminating the nee
 
 ## Model Configuration
 
-ExpressLRS stores separate configurations for each CRSF Receiver number configured in OpenTX/EdgeTX. This can be used with or without model matching - for example, a single drone being used for long-range and freestyle can have its RF params switched quickly by changing the model on the radio. The value is shown highlighted below on a TX16s.
+ExpressLRS stores separate configurations for each CRSF Receiver number configured in OpenTX/EdgeTX. This can be used with or without model matching.
+
+For example (without model match), a single drone being used for long-range and freestyle can have its RF params switched quickly by changing the model on the radio. 
+
+Conversely, enabling model match ensures the receiver only outputs control signals when the Receiver number and Model Match number match, preventing accidental control of the wrong aircraft. 
+
+The value is shown highlighted below on a TX16s.
 
 <figure markdown>
 ![model config](../assets/images/modelcfg.jpg){ width=80% }


### PR DESCRIPTION
Hi

When reading the excellent documentation I was briefly quite confused by the phrasing of the example in ## Model Configuration. 
After reaching out on [Discord](https://discordapp.com/channels/596350022191415318/798006228450017290/1401289429179432991) to clarify my understanding of the feature, I'm now quite sure, that the behavior mentioned in the example is only possible when Model Match is not used: 

"for example, a single drone being used for long-range and freestyle can have its RF params switched quickly by changing the model on the radio."

Since I might not be the only person that might get confused by the wording, I tried to rephrase it. 

Hence this PR.

(I didn't find any Contributions.md. In the README.md I didn't find any clear instructions how to contribute, so I hope this PR is adequate).

Best regards!
Christian