### PR TITLE
Update for V4 RFMDs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -63,6 +63,7 @@ DeadBot
 Disnator
 DisplayPort
 DivisionRc
+DK
 DLink
 EEA
 EL

--- a/docs/info/signal-health.md
+++ b/docs/info/signal-health.md
@@ -52,52 +52,52 @@ OSDs report the packet rate using an index instead of the actual rate, either as
 ![OSD RFMD](../assets/images/OSD_RFMD.png)
 
 === "ExpressLRS 4.x"
-| RFMD | Band | Lua | Packet Rate | Sensitivity <br/>Limit |
-|--|--|--|--|--|
-| 0 | 900 | 25Hz | 25Hz LoRa | -123dBm |
-| 1 | 900 | 50Hz | 50Hz LoRa | -120dBm |
-| 2 | 900 | 100Hz | 100Hz LoRa | -117dBm |
-| 3 | 900 | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa | -112dBm |
-| 5 | 900 | 200Hz | 200Hz LoRa | -112dBm |
-| 6 | 900 | 200Hz Full | 200Hz 8ch/12ch/16ch LoRa | -111dBm |
-| 7 | 900 | 250Hz | 250Hz LoRa | -111dBm |
-| 10 | 900 | D50 | 50Hz DVDA LoRa  | -112dBm |
-| 11 | 900 | K1000 Full | 1000Hz 8ch/12ch/16ch FSK | -101dBm |
-| 21 | 2.4 | 50Hz | 50Hz LoRa | -115dBm |
-| 23 | 2.4 | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa | -112dBm |
-| 24 | 2.4 | 150Hz | 150Hz LoRa | -112dBm |
-| 27 | 2.4 | 250Hz | 250Hz LoRa | -108dBm |
-| 28 | 2.4 | 333Hz Full | 333Hz 8ch/12ch/16ch LoRa | -105dBm |
-| 29 | 2.4 | 500Hz | 500Hz LoRa | -105dBm |
-| 30 | 2.4 | D250 | 250Hz DVDA FLRC | -104dBm |
-| 31 | 2.4 | D500 | 500Hz DVDA FLRC | -104dBm |
-| 32 | 2.4 | F500 | 500Hz FLRC | -104dBm |
-| 33 | 2.4 | F1000 | 1000Hz FLRC | -104dBm |
-| 34 | 2.4 | DK250 | 250Hz DVDA FSK | -103dBm |
-| 35 | 2.4 | DK500 | 500Hz DVDA FSK | -103dBm |
-| 36 | 2.4 | K1000 | 1000Hz FSK | -103dBm |
-| 100 | X-Band | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa Dual Band | -112dBm |
-| 101 | X-Band | 150Hz | 150Hz LoRa Dual Band | -112dBm |
+    | RFMD | Band | Lua | Packet Rate | Sensitivity <br/>Limit |
+    |--|--|--|--|--|
+    | 0 | 900 | 25Hz | 25Hz LoRa | -123dBm |
+    | 1 | 900 | 50Hz | 50Hz LoRa | -120dBm |
+    | 2 | 900 | 100Hz | 100Hz LoRa | -117dBm |
+    | 3 | 900 | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa | -112dBm |
+    | 5 | 900 | 200Hz | 200Hz LoRa | -112dBm |
+    | 6 | 900 | 200Hz Full | 200Hz 8ch/12ch/16ch LoRa | -111dBm |
+    | 7 | 900 | 250Hz | 250Hz LoRa | -111dBm |
+    | 10 | 900 | D50 | 50Hz DVDA LoRa  | -112dBm |
+    | 11 | 900 | K1000 Full | 1000Hz 8ch/12ch/16ch FSK | -101dBm |
+    | 21 | 2.4 | 50Hz | 50Hz LoRa | -115dBm |
+    | 23 | 2.4 | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa | -112dBm |
+    | 24 | 2.4 | 150Hz | 150Hz LoRa | -112dBm |
+    | 27 | 2.4 | 250Hz | 250Hz LoRa | -108dBm |
+    | 28 | 2.4 | 333Hz Full | 333Hz 8ch/12ch/16ch LoRa | -105dBm |
+    | 29 | 2.4 | 500Hz | 500Hz LoRa | -105dBm |
+    | 30 | 2.4 | D250 | 250Hz DVDA FLRC | -104dBm |
+    | 31 | 2.4 | D500 | 500Hz DVDA FLRC | -104dBm |
+    | 32 | 2.4 | F500 | 500Hz FLRC | -104dBm |
+    | 33 | 2.4 | F1000 | 1000Hz FLRC | -104dBm |
+    | 34 | 2.4 | DK250 | 250Hz DVDA FSK | -103dBm |
+    | 35 | 2.4 | DK500 | 500Hz DVDA FSK | -103dBm |
+    | 36 | 2.4 | K1000 | 1000Hz FSK | -103dBm |
+    | 100 | X-Band | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa Dual Band | -112dBm |
+    | 101 | X-Band | 150Hz | 150Hz LoRa Dual Band | -112dBm |
 
 === "ExpressLRS 3.x"
-| RFMD | Lua | Packet Rate | Sensitivity <br/>Limit | TX Duration <br/>(us) | TX Interval <br/>(us) |
-|:---:|:---:|:---:|---:|---:|---:|
-| 19 | K1000 Full | 1000Hz | -101dBm | 658 | 1000 |
-| 16 | DK500 | 500Hz | -101dBm | 690 | 1000 |
-| 14 | D50 | 50Hz | -112dBm | 4640.0 | 5000 |
-| 13 | F1000 | 1000Hz | -104dBm | 388.8 | 1000 |
-| 12 | F500 | 500Hz | -104dBm | 388.8 | 2000 |
-| 11 | D500 | 500Hz | -104dBm | 388.8 | 1000 |
-| 10 | D250 | 250Hz | -104dBm | 388.8 | 1000 |
-| 9 | 500Hz | 500Hz | -105dBm | 1507.4 | 2000 |
-| 8 | 333Hz Full | 333Hz | -105dBm | 2374.4 | 3003 |
-| 7 | 250Hz | 250Hz | -108dBm | 3330.0 | 4000 |
-| 6 | 200Hz | 200Hz | -112dBm | 4640.0 | 5000 |
-| 5 | 150Hz | 150Hz | -112dBm | 5891.9 | 6666 |
-| 4 | 100Hz Full | 100Hz | -112dBm | 6690.0 (900) /<br />7605.9 (2.4) | 10000 |
-| 3 | 100Hz | 100Hz | -117dBm | 9280.0 | 10000 |
-| 2 | 50Hz | 50Hz | -120dBm (900) /<br /> -115dBm (2.4) | 19580 (900) /<br /> 10798 (2.4) | 20000 |
-| 1 | 25Hz | 25Hz | -123dBm | 30980 | 40000 |
+    | RFMD | Lua | Packet Rate | Sensitivity <br/>Limit | TX Duration <br/>(us) | TX Interval <br/>(us) |
+    |:---:|:---:|:---:|---:|---:|---:|
+    | 19 | K1000 Full | 1000Hz | -101dBm | 658 | 1000 |
+    | 16 | DK500 | 500Hz | -101dBm | 690 | 1000 |
+    | 14 | D50 | 50Hz | -112dBm | 4640.0 | 5000 |
+    | 13 | F1000 | 1000Hz | -104dBm | 388.8 | 1000 |
+    | 12 | F500 | 500Hz | -104dBm | 388.8 | 2000 |
+    | 11 | D500 | 500Hz | -104dBm | 388.8 | 1000 |
+    | 10 | D250 | 250Hz | -104dBm | 388.8 | 1000 |
+    | 9 | 500Hz | 500Hz | -105dBm | 1507.4 | 2000 |
+    | 8 | 333Hz Full | 333Hz | -105dBm | 2374.4 | 3003 |
+    | 7 | 250Hz | 250Hz | -108dBm | 3330.0 | 4000 |
+    | 6 | 200Hz | 200Hz | -112dBm | 4640.0 | 5000 |
+    | 5 | 150Hz | 150Hz | -112dBm | 5891.9 | 6666 |
+    | 4 | 100Hz Full | 100Hz | -112dBm | 6690.0 (900) /<br />7605.9 (2.4) | 10000 |
+    | 3 | 100Hz | 100Hz | -117dBm | 9280.0 | 10000 |
+    | 2 | 50Hz | 50Hz | -120dBm (900) /<br /> -115dBm (2.4) | 19580 (900) /<br /> 10798 (2.4) | 20000 |
+    | 1 | 25Hz | 25Hz | -123dBm | 30980 | 40000 |
 
 ## What about SNR?
 SNR stands for Signal to Noise ratio and compares RSSI dBm to the RF background noise level and is in dB units (not dBm), higher is better. Notice it compares the background noise level and not the Sensitivity Limit. The reported value changes quite a bit from packet to packet and what values are good depend on what packet rate is being used. The RF chip can only approximate the noise level and only registers a value so high above the noise floor leading to this value getting clipped. Add to that, LoRa modulation can actually receive data below the noise floor to some degree.

--- a/docs/info/signal-health.md
+++ b/docs/info/signal-health.md
@@ -57,21 +57,14 @@ OSDs report the packet rate using an index instead of the actual rate, either as
 | 1 | 900 | 50Hz | 50Hz LoRa | -120dBm |
 | 2 | 900 | 100Hz | 100Hz LoRa | -117dBm |
 | 3 | 900 | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa | -112dBm |
-| 4 | 900 | 150Hz | 150Hz LoRa | N/A |
 | 5 | 900 | 200Hz | 200Hz LoRa | -112dBm |
 | 6 | 900 | 200Hz Full | 200Hz 8ch/12ch/16ch LoRa | -111dBm |
 | 7 | 900 | 250Hz | 250Hz LoRa | -111dBm |
-| 8 | 900 | 333Hz Full | 333Hz 8ch/12ch/16ch LoRa | N/A |
-| 9 | 900 | 500Hz | 500Hz LoRa | N/A |
 | 10 | 900 | D50 | 50Hz DVDA LoRa  | -112dBm |
 | 11 | 900 | K1000 Full | 1000Hz 8ch/12ch/16ch FSK | -101dBm |
-| 20 | 2.4 | 25Hz | 25Hz LoRa | N/A |
 | 21 | 2.4 | 50Hz | 50Hz LoRa | -115dBm |
-| 22 | 2.4 | 100Hz | 100Hz LoRa | N/A |
 | 23 | 2.4 | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa | -112dBm |
 | 24 | 2.4 | 150Hz | 150Hz LoRa | -112dBm |
-| 25 | 2.4 | 200Hz | 200Hz LoRa | N/A |
-| 26 | 2.4 | 200Hz Full | 200Hz 8ch/12ch/16ch LoRa | N/A |
 | 27 | 2.4 | 250Hz | 250Hz LoRa | -108dBm |
 | 28 | 2.4 | 333Hz Full | 333Hz 8ch/12ch/16ch LoRa | -105dBm |
 | 29 | 2.4 | 500Hz | 500Hz LoRa | -105dBm |

--- a/docs/info/signal-health.md
+++ b/docs/info/signal-health.md
@@ -51,6 +51,7 @@ OSDs report the packet rate using an index instead of the actual rate, either as
 
 ![OSD RFMD](../assets/images/OSD_RFMD.png)
 
+=== "ExpressLRS 4.x"
 | RFMD | Band | Lua | Packet Rate | Sensitivity <br/>Limit |
 |--|--|--|--|--|
 | 0 | 900 | 25Hz | 25Hz LoRa | -123dBm |
@@ -77,6 +78,24 @@ OSDs report the packet rate using an index instead of the actual rate, either as
 | 36 | 2.4 | K1000 | 1000Hz FSK | -103dBm |
 | 100 | X-Band | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa Dual Band | -112dBm |
 | 101 | X-Band | 150Hz | 150Hz LoRa Dual Band | -112dBm |
+
+=== "ExpressLRS 3.x"
+| RFMD | Lua | Packet Rate | Sensitivity <br/>Limit | TX Duration <br/>(us) | TX Interval <br/>(us) |
+|:---:|:---:|:---:|---:|---:|---:|
+| 14 | D50 | 50Hz | -112dBm | 4640.0 | 5000 |
+| 13 | F1000 | 1000Hz | -104dBm | 388.8 | 1000 |
+| 12 | F500 | 500Hz | -104dBm | 388.8 | 2000 |
+| 11 | D500 | 500Hz | -104dBm | 388.8 | 1000 |
+| 10 | D250 | 250Hz | -104dBm | 388.8 | 1000 |
+| 9 | 500Hz | 500Hz | -105dBm | 1507.4 | 2000 |
+| 8 | 333Hz Full | 333Hz | -105dBm | 2374.4 | 3003 |
+| 7 | 250Hz | 250Hz | -108dBm | 3330.0 | 4000 |
+| 6 | 200Hz | 200Hz | -112dBm | 4640.0 | 5000 |
+| 5 | 150Hz | 150Hz | -112dBm | 5891.9 | 6666 |
+| 4 | 100Hz Full | 100Hz | -112dBm | 6690.0 (900) /<br />7605.9 (2.4) | 10000 |
+| 3 | 100Hz | 100Hz | -117dBm | 9280.0 | 10000 |
+| 2 | 50Hz | 50Hz | -120dBm (900) /<br /> -115dBm (2.4) | 19580 (900) /<br /> 10798 (2.4) | 20000 |
+| 1 | 25Hz | 25Hz | -123dBm | 30980 | 40000 |
 
 ## What about SNR?
 SNR stands for Signal to Noise ratio and compares RSSI dBm to the RF background noise level and is in dB units (not dBm), higher is better. Notice it compares the background noise level and not the Sensitivity Limit. The reported value changes quite a bit from packet to packet and what values are good depend on what packet rate is being used. The RF chip can only approximate the noise level and only registers a value so high above the noise floor leading to this value getting clipped. Add to that, LoRa modulation can actually receive data below the noise floor to some degree.

--- a/docs/info/signal-health.md
+++ b/docs/info/signal-health.md
@@ -22,7 +22,7 @@ Both really. LQI is most important because you can't fly if you're not getting p
 
 ## RSSI Sensitivity Limit
 
-This is the lowest theoretical RSSI value that can be distinguished by the radio receiver. It is displayed next to the packet rate in the ELRS.lua script, as different packet rates and frequency bands have different sensitivity limits. Lower rates are more sensitive, -123dBm for 25Hz 915MHz up to -105dBm for 500Hz 2400MHz. This gives you the limit you know you can't fly below. 
+This is the lowest theoretical RSSI value that can be distinguished by the radio receiver. It is displayed next to the packet rate in the ELRS.lua script, as different packet rates and frequency bands have different sensitivity limits. Lower rates are more sensitive, -123dBm for 25Hz 915MHz up to -105dBm for 500Hz 2400MHz. This gives you the limit you know you can't fly below.
 
 A sensible warning value is 5-10dBm higher than the sensitivity limit shown in the [RF Mode Indexes](#rf-mode-indexes-rfmd) (e.g. 250Hz=-108dBm, so -103dBm to -98dBm for the alarm).
 
@@ -51,22 +51,39 @@ OSDs report the packet rate using an index instead of the actual rate, either as
 
 ![OSD RFMD](../assets/images/OSD_RFMD.png)
 
-| RFMD | Lua | Packet Rate | Sensitivity <br/>Limit | TX Duration <br/>(us) | TX Interval <br/>(us) |
-|:---:|:---:|:---:|---:|---:|---:|
-| 14 | D50 | 50Hz | -112dBm | 4640.0 | 5000 |
-| 13 | F1000 | 1000Hz | -104dBm | 388.8 | 1000 |
-| 12 | F500 | 500Hz | -104dBm | 388.8 | 2000 |
-| 11 | D500 | 500Hz | -104dBm | 388.8 | 1000 |
-| 10 | D250 | 250Hz | -104dBm | 388.8 | 1000 |
-| 9 | 500Hz | 500Hz | -105dBm | 1507.4 | 2000 |
-| 8 | 333Hz Full | 333Hz | -105dBm | 2374.4 | 3003 |
-| 7 | 250Hz | 250Hz | -108dBm | 3330.0 | 4000 |
-| 6 | 200Hz | 200Hz | -112dBm | 4640.0 | 5000 |
-| 5 | 150Hz | 150Hz | -112dBm | 5891.9 | 6666 |
-| 4 | 100Hz Full | 100Hz | -112dBm | 6690.0 (900) /<br />7605.9 (2.4) | 10000 |
-| 3 | 100Hz | 100Hz | -117dBm | 9280.0 | 10000 |
-| 2 | 50Hz | 50Hz | -120dBm (900) /<br /> -115dBm (2.4) | 19580 (900) /<br /> 10798 (2.4) | 20000 |
-| 1 | 25Hz | 25Hz | -123dBm | 30980 | 40000 |
+| RFMD | Band | Lua | Packet Rate | Sensitivity <br/>Limit |
+|--|--|--|--|--|
+| 0 | 900 | 25Hz | 25Hz LoRa | -123dBm |
+| 1 | 900 | 50Hz | 50Hz LoRa | -120dBm |
+| 2 | 900 | 100Hz | 100Hz LoRa | -117dBm |
+| 3 | 900 | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa | -112dBm |
+| 4 | 900 | 150Hz | 150Hz LoRa | N/A |
+| 5 | 900 | 200Hz | 200Hz LoRa | -112dBm |
+| 6 | 900 | 200Hz Full | 200Hz 8ch/12ch/16ch LoRa | -111dBm |
+| 7 | 900 | 250Hz | 250Hz LoRa | -111dBm |
+| 8 | 900 | 333Hz Full | 333Hz 8ch/12ch/16ch LoRa | N/A |
+| 9 | 900 | 500Hz | 500Hz LoRa | N/A |
+| 10 | 900 | D50 | 50Hz DVDA LoRa  | -112dBm |
+| 11 | 900 | K1000 Full | 1000Hz 8ch/12ch/16ch FSK | -101dBm |
+| 20 | 2.4 | 25Hz | 25Hz LoRa | N/A |
+| 21 | 2.4 | 50Hz | 50Hz LoRa | -115dBm |
+| 22 | 2.4 | 100Hz | 100Hz LoRa | N/A |
+| 23 | 2.4 | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa | -112dBm |
+| 24 | 2.4 | 150Hz | 150Hz LoRa | -112dBm |
+| 25 | 2.4 | 200Hz | 200Hz LoRa | N/A |
+| 26 | 2.4 | 200Hz Full | 200Hz 8ch/12ch/16ch LoRa | N/A |
+| 27 | 2.4 | 250Hz | 250Hz LoRa | -108dBm |
+| 28 | 2.4 | 333Hz Full | 333Hz 8ch/12ch/16ch LoRa | -105dBm |
+| 29 | 2.4 | 500Hz | 500Hz LoRa | -105dBm |
+| 30 | 2.4 | D250 | 250Hz DVDA FLRC | -104dBm |
+| 31 | 2.4 | D500 | 500Hz DVDA FLRC | -104dBm |
+| 32 | 2.4 | F500 | 500Hz FLRC | -104dBm |
+| 33 | 2.4 | F1000 | 1000Hz FLRC | -104dBm |
+| 34 | 2.4 | DK250 | 250Hz DVDA FSK | -103dBm |
+| 35 | 2.4 | DK500 | 500Hz DVDA FSK | -103dBm |
+| 36 | 2.4 | K1000 | 1000Hz FSK | -103dBm |
+| 100 | X-Band | 100Hz Full | 100Hz 8ch/12ch/16ch LoRa Dual Band | -112dBm |
+| 101 | X-Band | 150Hz | 150Hz LoRa Dual Band | -112dBm |
 
 ## What about SNR?
 SNR stands for Signal to Noise ratio and compares RSSI dBm to the RF background noise level and is in dB units (not dBm), higher is better. Notice it compares the background noise level and not the Sensitivity Limit. The reported value changes quite a bit from packet to packet and what values are good depend on what packet rate is being used. The RF chip can only approximate the noise level and only registers a value so high above the noise floor leading to this value getting clipped. Add to that, LoRa modulation can actually receive data below the noise floor to some degree.
@@ -112,6 +129,6 @@ Unfortunately, there is a misconception about the 2.4GHz range thanks to other r
 
 We have all heard the stories of racers powering up his TBS crossfire full module at 2W and causing people to fail-safe during a race. This happens because the 868/915MHz band has limited bandwidth. The solution for this is to use a low power mode during races, so you do not blast anyone out of the sky. 2.4GHz does not have this issue. Flite Test has a world record of having [179 RC airplanes](https://www.guinnessworldrecords.com/world-records/most-rc-model-aircraft-airborne-simultaneously#:~:text=The%20most%20RC%20model%20aircraft,USA%2C%20on%2016%20July%202016) in the sky using 2.4 GHz.
 
-2.4GHz LoRa can also handle WiFi noise very well. [Studies](https://link.springer.com/article/10.1007/s11235-020-00658-w) have been conducted with the coexistence of WiFi and LoRa bands. 
+2.4GHz LoRa can also handle WiFi noise very well. [Studies](https://link.springer.com/article/10.1007/s11235-020-00658-w) have been conducted with the coexistence of WiFi and LoRa bands.
 
 868/915 does not have to worry about WiFi signal but it does have to worry about cell towers and other RF noise. You are fighting against thermostats, fire systems, burglar systems and any other device running on that band.

--- a/docs/info/signal-health.md
+++ b/docs/info/signal-health.md
@@ -82,6 +82,8 @@ OSDs report the packet rate using an index instead of the actual rate, either as
 === "ExpressLRS 3.x"
 | RFMD | Lua | Packet Rate | Sensitivity <br/>Limit | TX Duration <br/>(us) | TX Interval <br/>(us) |
 |:---:|:---:|:---:|---:|---:|---:|
+| 19 | K1000 Full | 1000Hz | -101dBm | 658 | 1000 |
+| 16 | DK500 | 500Hz | -101dBm | 690 | 1000 |
 | 14 | D50 | 50Hz | -112dBm | 4640.0 | 5000 |
 | 13 | F1000 | 1000Hz | -104dBm | 388.8 | 1000 |
 | 12 | F500 | 500Hz | -104dBm | 388.8 | 2000 |


### PR DESCRIPTION
Removed TX Duration and TX Interval as these are technical and unnecessary. I also tried adding columns for SX128x / SX127x / LR1121 but the table got too wide :(

Should I remove the modes we do not support currently to keep the list shorter?