### PR TITLE
mDNS integration and Web UI connection documentation (Fixes #451)

### DIFF
--- a/docs/info/glossary.md
+++ b/docs/info/glossary.md
@@ -16,6 +16,7 @@ Below you can find a list of terms you might not be sure about, as well as some 
 - `LQ`: Link Quality, percentage of expected packets received. Our preferred method of measuring the quality of the control link
 - `Lua`: Means "Moon" in Portuguese. As such, Lua is the correct way to write and not all uppercase. The ExpressLRS Lua script can be installed on a OpenTX radio, to easily alter TX parameters like Packet rate, Telemetry ratio and Output power. But also shows if the radio (OpenTX) is communicating correctly with the module. ( e.g. 0:50, 0:150, 0:200 and so on.)
 - `MCU`: Micro Controller Unit, generally denotes an embedded system controller as opposed to big iron CPU
+- `mDNS`: Multicast DNS. It allows for hostnames (like `elrs_rx.local` or `elrs_tx.local`) to be resolved into IP addresses on a local network without the need for a dedicated DNS server.
 - `OSD`: On Screen Display, refer to [this page for instructions for setup in BF](../quick-start/pre-1stflight.md#rssi-and-link-quality)
 - `OTA`: Update your device `Over The Air` (WiFi)
 - `OTX`: OpenTX

--- a/docs/quick-start/receivers/firmware-version.md
+++ b/docs/quick-start/receivers/firmware-version.md
@@ -80,14 +80,14 @@ It is still recommended that you update your gear to the latest firmware version
         <br clear="right" />
 
     3. Load the Web UI on your browser using these addresses:
-        - http://10.0.0.1/ -If you have connected to the `ExpressLRS RX` Access Point
+        - [http://10.0.0.1/](http://10.0.0.1/) or [http://elrs_rx.local/](http://elrs_rx.local/) - If you are connected to the `ExpressLRS RX` Access Point.
             
             !!! Note
-                This IP address is also often used by some routers. Computers with an ethernet connection to their routers will find that this page doesn't load the ExpressLRS Web UI and instead loads their router or ISP modem configuration dashboards.
+                The IP address `10.0.0.1` is also often used by some routers. Computers with an ethernet connection to their routers will find that this page doesn't load the ExpressLRS Web UI and instead loads their router or ISP modem configuration dashboards.
 
                 We recommend disconnecting from the network first or trying a different device instead, e.g. smartphone or tablet.
         
-        - http://elrs_rx.local - If you have previously set your Home WiFi SSID and Password into your Receiver when you flashed it.
+        - [http://elrs_rx.local/](http://elrs_rx.local/) - If you have previously set your Home WiFi SSID and Password into your Receiver and it's connected to your local network.
 
             !!! Note
                 If your browser cannot resolve this address, chances are MDNS is not set up and working on your computer or network.

--- a/docs/quick-start/transmitters/firmware-version.md
+++ b/docs/quick-start/transmitters/firmware-version.md
@@ -104,14 +104,14 @@ There are three methods to determine what firmware version you currently have on
         <br clear="right" />
 
     3. Load the Web UI on your browser using these addresses:
-        - http://10.0.0.1/ -If you have connected to the `ExpressLRS TX` Access Point
+        - [http://10.0.0.1/](http://10.0.0.1/) or [http://elrs_tx.local/](http://elrs_tx.local/) - If you are connected to the `ExpressLRS TX` Access Point.
             
             !!! Note
-                This IP address is also often used by some routers. Computers with an ethernet connection to their routers will find that this page doesn't load the ExpressLRS Web UI and instead loads their router or ISP modem configuration dashboards.
+                The IP address `10.0.0.1` is also often used by some routers. Computers with an ethernet connection to their routers will find that this page doesn't load the ExpressLRS Web UI and instead loads their router or ISP modem configuration dashboards.
 
                 We recommend disconnecting from the network first or trying a different device instead, e.g. smartphone or tablet.
         
-        - http://elrs_tx.local - If you have previously set your Home WiFi SSID and Password into your TX Module when you flashed it.
+        - [http://elrs_tx.local/](http://elrs_tx.local/) - If you have previously set your Home WiFi SSID and Password into your TX Module and it's connected to your local network.
 
             !!! Note
                 If your browser cannot resolve this address, chances are MDNS is not set up and working on your computer or network.

--- a/docs/quick-start/troubleshooting.md
+++ b/docs/quick-start/troubleshooting.md
@@ -203,6 +203,16 @@ description: Stuck on your ExpressLRS setup? Let us help you with that! Here's s
 
     To ensure that the WiFi flashing is finished properly, **wait until the LED on the receiver blinks slowly** (indicating it's looking for a TX bind) before pulling off power.
 
+### <span class="custom-heading" data-id="24">I cannot reach http://elrs_tx.local or http://elrs_rx.local</span>
+
+??? Note "I cannot reach http://elrs_tx.local or http://elrs_rx.local"
+    This is usually because mDNS is not working on your network or device. 
+    
+    *   **Verify Connection:** Ensure your device (phone/laptop) is on the **same** WiFi network as the ExpressLRS device.
+    *   **OS Support:** While most modern OSs support mDNS, some older versions of Windows or specific Linux configurations might not. 
+    *   **Router Settings:** Some routers block multicast traffic between wireless clients (often called "AP Isolation" or "Client Isolation"). Disable this setting if possible.
+    *   **Use the IP Address:** If the `.local` address doesn't work, you can always use the IP address. If the device is in AP mode (hotspot), it's always `http://10.0.0.1/`. If it's on your home WiFi, check your router's DHCP list for a device named `elrs`.
+
 If you have other questions or concerns, or maybe you need further help that is not covered by this Guide, head over to our Discord Channel or Facebook Group!
 
 <span style="padding-left:10%; display:inline; text-align:center">[ExpressLRS Discord :fontawesome-brands-discord:](https://discord.gg/dS6ReFY){ .md-button }</span>

--- a/docs/quick-start/webui.md
+++ b/docs/quick-start/webui.md
@@ -117,7 +117,7 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
 
     3. Load the Web UI on your browser. The address depends on how the Receiver is connected:
         
-        *   **Access Point Mode:** If you are connected to the `ExpressLRS RX` WiFi hotspot, use [http://10.0.0.1/](http://10.0.0.1/).
+        *   **Access Point Mode:** While connected to the `ExpressLRS RX` hotspot, almost any hostname (e.g., [http://elrs_rx.local/](http://elrs_rx.local/)) should resolve to the Web UI. However, if your browser or OS doesn't redirect automatically, use [http://10.0.0.1/](http://10.0.0.1/) as a direct fallback.
 
             !!! Note
                 This IP address is also often used by some routers. Computers with an ethernet connection to their routers will find that this page doesn't load the ExpressLRS Web UI and instead loads their router or ISP modem configuration dashboards.
@@ -125,9 +125,9 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
                 We recommend disconnecting from the network first or trying a different device instead, e.g. smartphone or tablet.
 
             !!! Note
-                On some devices a network login prompt might pop up. Clicking this will often show an incomplete version of the webui that won't behave as expected. Please navigate to http://10.0.0.1/ manually in your browser instead.
+                On some devices a network login prompt might pop up. Clicking this will often show an incomplete version of the webui that won't behave as expected. Please navigate to http://10.0.0.1/ (or http://elrs_rx.local/) manually in your browser instead.
 
-        *   **Home WiFi Mode:** If the Receiver is connected to your local network, use [http://elrs_rx.local/](http://elrs_rx.local/).
+        *   **Home WiFi Mode:** If the Receiver is connected to your local network, use [http://elrs_rx.local/](http://elrs_rx.local/). (Note: Hostnames also work in Access Point Mode).
 
             !!! Note
                 If your browser cannot resolve this address, chances are mDNS is not set up and working on your computer or network.
@@ -194,7 +194,7 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
 
     3. Load the Web UI on your browser. The address depends on how the TX Module is connected:
         
-        *   **Access Point Mode:** If you are connected to the `ExpressLRS TX` WiFi hotspot, use [http://10.0.0.1/](http://10.0.0.1/).
+        *   **Access Point Mode:** While connected to the `ExpressLRS TX` hotspot, almost any hostname (e.g., [http://elrs_tx.local/](http://elrs_tx.local/)) should resolve to the Web UI. However, if your browser or OS doesn't redirect automatically, use [http://10.0.0.1/](http://10.0.0.1/) as a direct fallback.
 
             !!! Note
                 This IP address is also often used by some routers. Computers with an ethernet connection to their routers will find that this page doesn't load the ExpressLRS Web UI and instead loads their router or ISP modem configuration dashboards.
@@ -202,9 +202,9 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
                 We recommend disconnecting from the network first or trying a different device instead, e.g. smartphone or tablet.
 
             !!! Note
-                On some devices a network login prompt might pop up. Clicking this will often show an incomplete version of the webui that won't behave as expected. Please navigate to http://10.0.0.1/ manually in your browser instead.
+                On some devices a network login prompt might pop up. Clicking this may show an incomplete version of the webui that won't behave as expected. Please navigate to http://10.0.0.1/ (or http://elrs_tx.local/) manually in your browser instead.
 
-        *   **Home WiFi Mode:** If the TX Module is connected to your local network, use [http://elrs_tx.local/](http://elrs_tx.local/).
+        *   **Home WiFi Mode:** If the TX Module is connected to your local network, use [http://elrs_tx.local/](http://elrs_tx.local/). (Note: Hostnames also work in Access Point Mode).
 
             !!! Note
                 If your browser cannot resolve this address, chances are mDNS is not set up and working on your computer or network.

--- a/docs/quick-start/webui.md
+++ b/docs/quick-start/webui.md
@@ -6,6 +6,8 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/quick-start.png)
 
 ## How to get to the Web UI
+
+
 === "Receivers"
    
     1. Put your Receiver into WiFi Mode.
@@ -113,8 +115,9 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
 
         <br clear="right" />
 
-    3. Load the Web UI on your browser using these addresses:
-        - http://10.0.0.1/ - If you have connected to the `ExpressLRS RX` Access Point
+    3. Load the Web UI on your browser. The address depends on how the Receiver is connected:
+        
+        *   **Access Point Mode:** If you are connected to the `ExpressLRS RX` WiFi hotspot, use [http://10.0.0.1/](http://10.0.0.1/).
 
             !!! Note
                 This IP address is also often used by some routers. Computers with an ethernet connection to their routers will find that this page doesn't load the ExpressLRS Web UI and instead loads their router or ISP modem configuration dashboards.
@@ -124,23 +127,23 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
             !!! Note
                 On some devices a network login prompt might pop up. Clicking this will often show an incomplete version of the webui that won't behave as expected. Please navigate to http://10.0.0.1/ manually in your browser instead.
 
-        - http://elrs_rx.local - If you have previously set your Home WiFi SSID and Password into your Receiver when you flashed it.
+        *   **Home WiFi Mode:** If the Receiver is connected to your local network, use [http://elrs_rx.local/](http://elrs_rx.local/).
 
             !!! Note
-                If your browser cannot resolve this address, chances are MDNS is not set up and working on your computer or network.
+                If your browser cannot resolve this address, chances are mDNS is not set up and working on your computer or network.
 
             ??? tip "Use the IP Address instead! (click/tap to expand)"
                 === "The `arp` Command"
-
-                    1. Open up a Command Prompt window on your computer.
+                    1. Open a terminal or command prompt on your computer.
                     2. Execute the command `arp -a` which will list all the devices in the Network.
-                    3. Try each of the IP Addresses marked as `Dynamic` as a URL in your Browser until you get to the ExpressLRS Web UI.
+                    3. Look for the list of dynamic IP addresses. On most networks, ExpressLRS devices will appear with a MAC address starting with `30-ae-a4`, `24-4c-6a`, or `84-f3-eb` (standard Espressif/ESP prefixes).
+                    4. Try each of these IP addresses in your browser until you reach the ExpressLRS Web UI.
 
                 === "Router DHCP List"
-                    1. Log in to your Router dashboard.
-                    2. Check the DHCP List and look for the "elrs" device.
-                    3. Take note of the IP Address given by your router.
-                    4. Use this IP address in your Browser as the URL.
+                    1. Log in to your router's web interface (usually `192.168.1.1` or `192.168.0.1`).
+                    2. Navigate to the "Attached Devices" or "DHCP Client List" section.
+                    3. Look for a device named `elrs-rx`. If the name isn't showing up, look for a device with an "Espressif" manufacturer tag.
+                    4. Use the IP address assigned to this device in your browser.
     
 === "TX Modules"
 
@@ -189,8 +192,9 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
 
         <br clear="right" />
 
-    3. Load the Web UI on your browser using these addresses:
-        - http://10.0.0.1/ - If you have connected to the `ExpressLRS TX` Access Point
+    3. Load the Web UI on your browser. The address depends on how the TX Module is connected:
+        
+        *   **Access Point Mode:** If you are connected to the `ExpressLRS TX` WiFi hotspot, use [http://10.0.0.1/](http://10.0.0.1/).
 
             !!! Note
                 This IP address is also often used by some routers. Computers with an ethernet connection to their routers will find that this page doesn't load the ExpressLRS Web UI and instead loads their router or ISP modem configuration dashboards.
@@ -200,23 +204,23 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
             !!! Note
                 On some devices a network login prompt might pop up. Clicking this will often show an incomplete version of the webui that won't behave as expected. Please navigate to http://10.0.0.1/ manually in your browser instead.
 
-        - http://elrs_tx.local - If you have previously set your Home WiFi SSID and Password into your TX Module when you flashed it.
+        *   **Home WiFi Mode:** If the TX Module is connected to your local network, use [http://elrs_tx.local/](http://elrs_tx.local/).
 
             !!! Note
-                If your browser cannot resolve this address, chances are MDNS is not set up and working on your computer or network.
+                If your browser cannot resolve this address, chances are mDNS is not set up and working on your computer or network.
 
             ??? tip "Use the IP Address instead! (click/tap to expand)"
                 === "The `arp` Command"
-
-                    1. Open up a Command Prompt window on your computer.
+                    1. Open a terminal or command prompt on your computer.
                     2. Execute the command `arp -a` which will list all the devices in the Network.
-                    3. Try each of the IP Addresses marked as `Dynamic` as a URL in your Browser until you get to the ExpressLRS Web UI.
+                    3. Look for the list of dynamic IP addresses. On most networks, ExpressLRS devices will appear with a MAC address starting with `30-ae-a4`, `24-4c-6a`, or `84-f3-eb` (standard Espressif/ESP prefixes).
+                    4. Try each of these IP addresses in your browser until you reach the ExpressLRS Web UI.
 
                 === "Router DHCP List"
-                    1. Log in to your Router dashboard.
-                    2. Check the DHCP List and look for the "elrs" device.
-                    3. Take note of the IP Address given by your router.
-                    4. Use this IP address in your Browser as the URL.
+                    1. Log in to your router's web interface (usually `192.168.1.1` or `192.168.0.1`).
+                    2. Navigate to the "Attached Devices" or "DHCP Client List" section.
+                    3. Look for a device named `elrs-tx`. If the name isn't showing up, look for a device with an "Espressif" manufacturer tag.
+                    4. Use the IP address assigned to this device in your browser.
 
 ## The ExpressLRS Web UI Explained
 


### PR DESCRIPTION
Description
This PR resolves Issue #451 by documenting how users access the ExpressLRS Web UI using http://elrs_rx.local/ and http://elrs_tx.local/ . 

Key Changes
Glossary Expansion (glossary.md): Added a formal definition for mDNS to explain the technical foundation of .local resolution.

Web UI Access Documentation (webui.md):  Restructured access instructions into clear Access Point Mode vs. Home WiFi Mode sections for both RX and TX. Integrated mDNS hostnames as the primary access method for networked devices.Added arp command guide with specific Espressif MAC prefixes (30-ae-a4, 24-4c-6a, 84-f3-eb) to help users identify ELRS hardware in a list of dynamic IPs. Added the Router DHCP guide with specific device naming conventions (elrs-tx/elrs-rx).

Connection Troubleshooting (troubleshooting.md): Added a dedicated section for "Cannot reach .local addresses," covering common blockers like AP Isolation and OS compatibility.

Related Issues
Closes #451