### PR TITLE
Fix #464: Resolve broken links and MkDocs build warnings

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,7 +42,7 @@ hide:
 ## <span class="custom-heading" data-id="7">What is required to achieve a 1000 Hz update rate on 2.4 GHz?</span>
 
 ??? faq "What is required to achieve a 1000 Hz packet rate on 2.4 GHz?"
-    In order to achieve the fastest packet rate, your radio must be running a supported [firmware](quick-start/transmitters/tx-prep.md#radio-operating-system), set to a minimum [hardware baud rate](quick-start/transmitters/tx-prep.md#serial-baud-rate) of 921000, and be connected to a serial ELRS receiver (SPI receivers do not support the FLRC modes required). Also make absolutely sure [ADC filter](quick-start/transmitters/tx-prep.md#adc-filter) is disabled on your radio, and that you have applied the appropriate RC Link [Preset](https://betaflight.com/docs/wiki/configurator/presets-tab) in Betaflight. 
+    In order to achieve the fastest packet rate, your radio must be running a supported [firmware](quick-start/transmitters/tx-prep.md#radio-operating-system), set to a minimum [hardware baud rate](quick-start/transmitters/tx-prep.md#serial-baud-rate) of 921000, and be connected to a serial ELRS receiver (SPI receivers do not support the FLRC modes required). Also make absolutely sure [ADC filter](quick-start/transmitters/tx-prep.md#adc-filter) is disabled on your radio, and that you have applied the appropriate RC Link [Preset](https://betaflight.com/docs/wiki/app/presets-tab) in Betaflight. 
 
     You can use the ELRS lua to check your current packet rate and ensure the radio mixer sync is working properly. See [Using the Lua Script](quick-start/transmitters/lua-howto.md) for more details.
 

--- a/docs/gsod.md
+++ b/docs/gsod.md
@@ -125,7 +125,7 @@ Our initial timeline has been heavily delayed through the delivery of hardware t
 
 **Results**
 
-[A number of PRs were merged](https://github.com/ExpressLRS/Docs/pulls?q=is%3Apr+author%3AAghaSaad04) by the Technical Writer, which include major technical topics/issues such as [Crystal Oscillator (XO) Frequency Error](https://github.com/ExpressLRS/Docs/pull/256).  However key beginner documents were difficult without hardware for our writer to have hands on experience with.
+[A number of PRs were merged](https://github.com/ExpressLRS/Docs/pulls?q=is%3Apr+author%3AAghaSaad04) by the Technical Writer, which include major technical topics/issues such as [Crystal Oscillator (XO) Frequency Error](https://github.com/ExpressLRS/ExpressLRS/pull/256).  However key beginner documents were difficult without hardware for our writer to have hands on experience with.
 
 **Metrics**
 

--- a/docs/hardware/backpack/backpack-tx-setup.md
+++ b/docs/hardware/backpack/backpack-tx-setup.md
@@ -28,8 +28,8 @@ Applies to: Older TX modules that have DIP switches or jumper pins, e.g. `Happym
 
 For older TX modules like the Happymodel TX Modules, you will need to move the jumpers or DIP switches into the correct position before flashing the firmware. Please see the USB/UART Flashing section of your particular TX Module for the jumper or DIP switch position.
 
-- [ES24TX Jumpers](../../quick-start/transmitters/es24tx.md/#via-uart)
-- [ES900TX Jumpers](../../quick-start/transmitters/es900tx.md/#via-uart)
+- [ES24TX Jumpers](../../quick-start/transmitters/es24tx.md#via-uart)
+- [ES900TX Jumpers](../../quick-start/transmitters/es900tx.md#via-uart)
 
 You need to activate the `Backpack Flashing` jumper or DIP switch (middle pair). Opening up the module enclosure will be needed as well to access the Buttons on the modules. Make sure your computer recognizes your TX module as a `USB to UART Bridge`. Windows drivers are linked in the Flashing Guides.
 
@@ -87,7 +87,7 @@ Applies to: All TX modules that have a Backpack (this method assumes that the Ba
 
 ### Flashing via WiFi (older NamimnoRC Gen1 TX Modules)
 
-For the First Generation NamimnoRC TX modules (No OLED), you will have to first `Build` the Backpack firmware. Once built, grab the `backpack.bin` file from the folder that the ExpressLRS Configurator opened. Open the URL http://elrs_tx.local on your browser and scroll down to where the **WiFi Backpack Firmware Update** section is (shown in the image below). If the page isn't loading, make sure you have followed the Wifi Flashing guide for these modules (see [Flashing Guide](../../quick-start/transmitters/flash2400.md/#via-wifi)).
+For the First Generation NamimnoRC TX modules (No OLED), you will have to first `Build` the Backpack firmware. Once built, grab the `backpack.bin` file from the folder that the ExpressLRS Configurator opened. Open the URL http://elrs_tx.local on your browser and scroll down to where the **WiFi Backpack Firmware Update** section is (shown in the image below). If the page isn't loading, make sure you have followed the Wifi Flashing guide for these modules (see [Flashing Guide](../../quick-start/transmitters/flash2400.md#via-wifi)).
 
 <figure markdown>
 ![Wifi Backpack](../../assets/images/backpackwifi.png)

--- a/docs/hardware/crystal-frequency-error.md
+++ b/docs/hardware/crystal-frequency-error.md
@@ -51,7 +51,7 @@ Caution: don't use Continuous Wave mode for longer periods of time to avoid exce
 
 ### Measuring relative XO error between a TX-RX pair
 
-You'll need to use "Manual mode" in the configurator to enable a special debug mode. In addition to this debug mode flag, you should add any other user defines you need to get your TX/RX to connect (check the [user defines section](https://www.expresslrs.org/3.0/software/user-defines/)).
+You'll need to use "Manual mode" in the configurator to enable a special debug mode. In addition to this debug mode flag, you should add any other user defines you need to get your TX/RX to connect (check the [user defines section](https://www.expresslrs.org/software/user-defines/)).
 
 For example, this might look like (which is safe to just copy-paste in general):
 

--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -96,19 +96,19 @@ To install the correct 'RC Link Preset', follow these steps in **Betaflight Conf
 
 1. Select the **Preset** tab
 1. In the preset tab, select **Save Backup** and save a backup to a safe location before applying any preset.
-1. Search for 'ExpressLRS' and select the Link Preset that matches your [Packet Rate](../transmitters/lua-howto.md#packet-rate-and-telemetry-ratio). If no direct match is available, choose the closest preset below your packet rate.
+1. Search for 'ExpressLRS' and select the Link Preset that matches your [Packet Rate](transmitters/lua-howto.md#packet-rate-and-telemetry-ratio). If no direct match is available, choose the closest preset below your packet rate.
 
-    ![Presets Home](../../assets/images/preset_home.png)
+    ![Presets Home](../assets/images/preset_home.png)
 
 1. Read through the options by selecting the dropdown list. NOTE: These are all optional, if none of them apply to your circumstances, it is OK to leave everything unticked.
 
 1. Select 'Pick' to stage the preset:
 
-    ![Presets Pick](../../assets/images/preset_pick.png)
+    ![Presets Pick](../assets/images/preset_pick.png)
     
 1. Select **Save and Reboot** to apply the preset:
 
-    ![Presets Save](../../assets/images/preset_save.png)
+    ![Presets Save](../assets/images/preset_save.png)
 
 ## Blackbox
 

--- a/docs/quick-start/transmitters/es24tx.md
+++ b/docs/quick-start/transmitters/es24tx.md
@@ -333,6 +333,7 @@ template: main.html
         13. On your Radio, the `WiFi Running` screen should disappear and should be back to the WiFi Connectivity Menu of the ExpressLRS Lua Script.
         14. Long-press the ++"RTN"++ Key to exit the ExpressLRS Lua Script. Then reload it to check for the ExpressLRS Firmware version and verify your TX module has been updated.
 
+<a name="via-uart"></a>
 === "via UART"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/es900tx.md
+++ b/docs/quick-start/transmitters/es900tx.md
@@ -324,6 +324,7 @@ template: main.html
         13. On your Radio, the `WiFi Running` screen should disappear and should be back to the WiFi Connectivity Menu of the ExpressLRS Lua Script.
         14. Long-press the ++"RTN"++ Key to exit the ExpressLRS Lua Script. Then reload it to check for the ExpressLRS Firmware version and verify your TX module has been updated.
 
+<a name="via-uart"></a>
 === "via UART"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/firmware-version.md
+++ b/docs/quick-start/transmitters/firmware-version.md
@@ -14,6 +14,7 @@ It is still recommended that you update your gear to the latest firmware version
 ## Transmitter Module Firmware Version
 There are three methods to determine what firmware version you currently have on your Transmitter module
 
+<a name="via-lua-script"></a>
 === "via Lua Script"
 
     1. Press the ++"SYS"++ Key on your Radio.

--- a/docs/quick-start/transmitters/flash2400.md
+++ b/docs/quick-start/transmitters/flash2400.md
@@ -15,6 +15,7 @@ template: main.html
 
     Updating to 3.x via UART or ETX Passthrough doesn't require 2.5.2 firmware or the Repartitioner.
 
+<a name="via-wifi"></a>
 === "via WiFi"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/frsky-r9modules.md
+++ b/docs/quick-start/transmitters/frsky-r9modules.md
@@ -93,6 +93,7 @@ template: main.html
 
     13. With the [ExpressLRS Lua Script] in the System Menu's Tools page, verify if the firmware version has been updated.
 
+<a name="via-stlink"></a>
 === "via STLink"
 
     <figure markdown>

--- a/docs/quick-start/transmitters/lua-howto.md
+++ b/docs/quick-start/transmitters/lua-howto.md
@@ -137,6 +137,7 @@ The following options will be available:
 
 - 900MHz
 
+<a name="packet-rate-and-telemetry-ratio"></a>
 ### Packet Rate and Telemetry Ratio
 
 <figure markdown>
@@ -382,7 +383,7 @@ If the connected receiver is a PWM receiver, you will also have options to set O
 ![Output Mapping](../../assets/images/lua/lua-otherRX-mapping.png)
 </figure>
 
-The controls here are similar to what you see on the Connections tab in the [Web UI](../webui/#connections-tab). So,
+The controls here are similar to what you see on the Connections tab in the [Web UI](../webui.md#connections-tab). So,
 
 * `Output Ch` - selects the actual PWM channel you are managing. When you change this value, the other inputs will be changed to the current values configured in the receiver for that channel and you can view or change them.
 * `Input Ch` - selects which over-the-air channel to route to the selected output. For example, if you are using traditional Channel 5 ARM but you don't want to lose the use of PWM Output 5, you can map input channel 6 to output channel 5.

--- a/docs/software/airport.md
+++ b/docs/software/airport.md
@@ -6,7 +6,7 @@ description: ExpressLRS can be configured as a bi-directional transparent serial
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)
 
 !!! note "NOTE"
-    With the addition of [MAVLink](../mavlink/) support in ELRS 3.5, it is no longer recommended to use Airport for MAVLink telemetry. Please see the [MAVLink](../mavlink/) page for more info.
+    With the addition of [MAVLink](mavlink.md) support in ELRS 3.5, it is no longer recommended to use Airport for MAVLink telemetry. Please see the [MAVLink](mavlink.md) page for more info.
 	
 ## Description
 

--- a/docs/software/backpack-telemetry.md
+++ b/docs/software/backpack-telemetry.md
@@ -13,7 +13,7 @@ Version 3.4+ of ELRS introduces a new option in the Backpack section of the ELRS
 <figcaption>Sentinel Integration</figcaption>
 </figure>
 
-This capability is particularly useful for devices like the Sentinel Antenna Tracker, which can subscribe to ESPNOW telemetry packets and read GPS data from the telemetry feed. See [the Sentinel product page](https://www.virtualpilot.co.uk/index.php?route=product/product&product_id=59)
+This capability is particularly useful for devices like the Sentinel Antenna Tracker, which can subscribe to ESPNOW telemetry packets and read GPS data from the telemetry feed. See [the Sentinel product page](https://virtualpilot.co.uk/)
 
 ## Prerequisites
 - ELRS transmitter and receiver with the latest firmware.

--- a/docs/software/serialvtx.md
+++ b/docs/software/serialvtx.md
@@ -18,11 +18,11 @@ ExpressLRS now has support for controlling an external video transmitter through
 
 ## Hardware Requirements
 
-Using serial VTX control requires at least a secondary UART TX pin assigned on your ESP32-based receiver, such as the RadioMaster RP4TD or the BetaFPV SuperP. You may need to assign a pin as Serial TX using the Lua script "Other devices" section, or using the [RX Web UI](../../quick-start/webui/) if one is not already set up.
+Using serial VTX control requires at least a secondary UART TX pin assigned on your ESP32-based receiver, such as the RadioMaster RP4TD or the BetaFPV SuperP. You may need to assign a pin as Serial TX using the Lua script "Other devices" section, or using the [RX Web UI](../quick-start/webui.md) if one is not already set up.
 
 ## Software Requirements
 
-Ensure both your transmitter module and your receiver are up to date with the latest release versions; follow the [Firmware Update Guide](../../quick-start/getting-started/) for detailed instructions.
+Ensure both your transmitter module and your receiver are up to date with the latest release versions; follow the [Firmware Update Guide](../quick-start/getting-started.md) for detailed instructions.
 
 The minimum version to use this feature is:
 - Receiver firmware: `3.5.0`
@@ -41,7 +41,7 @@ The minimum version to use this feature is:
 
 1. Select "BACK" to return to the main Lua menu
 
-1. You can now use the ExpressLRS [VTX Administrator](../../quick-start/transmitters/lua-howto#vtx-administrator) function to control your VTX
+1. You can now use the ExpressLRS [VTX Administrator](../quick-start/transmitters/lua-howto.md#vtx-administrator) function to control your VTX
 
 ## Implementation details
 


### PR DESCRIPTION
Fixed a variety of documentation bugs to stabilize the build and improve navigation:

- Internal: Fixed broken relative paths and added anchors for deep-linked tabbed content.

- External: Audited 267 URLs; updated redirects for Betaflight and Sentinel Tracker.

- Images: Restored missing RC Link Preset images.

Verified with a strict build in the project Docker environment.