### PR TITLE
Add llms.txt

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,1 +1,5 @@
+---
+description: ExpressLRS project news, updates, and announcements.
+---
+
 # Blog

--- a/docs/contact-us.md
+++ b/docs/contact-us.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Contact ExpressLRS for inquiries, partnerships, or community support.
 hide:
   - navigation
 ---

--- a/docs/hardware/special-targets/diy-rx.md
+++ b/docs/hardware/special-targets/diy-rx.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Building custom ESP-based ExpressLRS receivers for 2.4GHz and 900MHz.
 ---
 ![Hardware-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/hardware.png)
 

--- a/docs/hardware/special-targets/diy-tx.md
+++ b/docs/hardware/special-targets/diy-tx.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Building custom ESP-based ExpressLRS transmitter modules for JR and lite bays.
 ---
 
 ![Hardware-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/hardware.png)

--- a/docs/hardware/special-targets/nuclear-hardware.md
+++ b/docs/hardware/special-targets/nuclear-hardware.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: The Nuclear RX — an ultra-compact 2.4GHz DIY receiver with 20x20 mounting.
 ---
 
 ![HW Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/hardware.png)

--- a/docs/info/advance-technical-info.md
+++ b/docs/info/advance-technical-info.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Technical debugging reference for LUA status codes and debug logging defines.
 ---
 
 ![Info Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/information.png)

--- a/docs/info/glossary.md
+++ b/docs/info/glossary.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Glossary of ExpressLRS terms, abbreviations, and technical concepts.
 ---
 
 ![Info Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/information.png)

--- a/docs/info/telem-bandwidth.md
+++ b/docs/info/telem-bandwidth.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Telemetry burst mode bandwidth allocation across packet rates and telemetry ratios.
 ---
 
 ![Info Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/information.png)

--- a/docs/partners-program.md
+++ b/docs/partners-program.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Partner with ExpressLRS to develop compatible hardware and join the official ecosystem.
 hide:
   - navigation
 ---

--- a/docs/quick-start/receivers/axisflying-thor.md
+++ b/docs/quick-start/receivers/axisflying-thor.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Axisflying Thor 2.4GHz receiver via WiFi, Passthrough, or UART.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/betafpv-superd.md
+++ b/docs/quick-start/receivers/betafpv-superd.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the BetaFPV SuperD 2.4GHz diversity receiver.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/betafpv-superd900.md
+++ b/docs/quick-start/receivers/betafpv-superd900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the BetaFPV SuperD 900MHz diversity receiver.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/betafpv2400.md
+++ b/docs/quick-start/receivers/betafpv2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for BetaFPV Lite, Nano, and AIO 2.4GHz receivers.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/betafpv900.md
+++ b/docs/quick-start/receivers/betafpv900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the BetaFPV Nano 900MHz receiver via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/diy2400.md
+++ b/docs/quick-start/receivers/diy2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for DIY 2.4GHz receivers with ESP8285 and STM32 options.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/diy900.md
+++ b/docs/quick-start/receivers/diy900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for DIY 900MHz receivers using ESP8285 with SX127x RF chips.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/flash2400.md
+++ b/docs/quick-start/receivers/flash2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for NamimnoRC Flash 2.4GHz receiver variants (ESP and STM32).
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/foxeer2400.md
+++ b/docs/quick-start/receivers/foxeer2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for Foxeer LNA and Lite 2.4GHz receivers via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/geprc2400.md
+++ b/docs/quick-start/receivers/geprc2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for GEPRC Nano and Dual 2.4GHz receivers via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/geprc900.md
+++ b/docs/quick-start/receivers/geprc900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for GEPRC Nano and Dual 900MHz receivers via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/ghost2400.md
+++ b/docs/quick-start/receivers/ghost2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for ImmersionRC Ghost Atto and Zepto 2.4GHz STM32 receivers via STLink.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/hglrc-hermes2400.md
+++ b/docs/quick-start/receivers/hglrc-hermes2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the HGLRC Hermes 2.4GHz receiver via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/hglrc-hermes900.md
+++ b/docs/quick-start/receivers/hglrc-hermes900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the HGLRC Hermes 900MHz receiver via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/hmep2400.md
+++ b/docs/quick-start/receivers/hmep2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Happymodel EP 2.4GHz receiver via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/hmes900.md
+++ b/docs/quick-start/receivers/hmes900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Happymodel ES900RX 900MHz receiver via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/hmpp2400.md
+++ b/docs/quick-start/receivers/hmpp2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Happymodel PP STM32-based 2.4GHz receiver via UART.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/iflight2400.md
+++ b/docs/quick-start/receivers/iflight2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for iFlight 2.4GHz Dipole and SMD receiver variants.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/iflight900.md
+++ b/docs/quick-start/receivers/iflight900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the iFlight 900MHz Dipole receiver via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/jumper-aion.md
+++ b/docs/quick-start/receivers/jumper-aion.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Jumper Aion Mini and Nano 2.4GHz receivers.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/jumper900.md
+++ b/docs/quick-start/receivers/jumper900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Jumper R9 Mini STM32-based 900MHz receiver via STLink.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/matek2400.md
+++ b/docs/quick-start/receivers/matek2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for Matek R24-D Diversity and R24-S SMD 2.4GHz receivers.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/r9.md
+++ b/docs/quick-start/receivers/r9.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for FrSky R9 STM32-based 900MHz receivers via bootloader or STLink.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/radiomaster-rp-2400.md
+++ b/docs/quick-start/receivers/radiomaster-rp-2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for RadioMaster RP1 and RP2 2.4GHz receivers via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/siyiFRmini.md
+++ b/docs/quick-start/receivers/siyiFRmini.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the SIYI FR Mini STM32-based receiver via STLink.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/vantac2400.md
+++ b/docs/quick-start/receivers/vantac2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Vantac 2.4GHz receiver via WiFi or Passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/receivers/voyager900.md
+++ b/docs/quick-start/receivers/voyager900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for NamimnoRC Voyager 900MHz receiver variants (ESP and STM32).
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/aion-internal.md
+++ b/docs/quick-start/transmitters/aion-internal.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for Jumper T-Pro internal 2.4GHz and 900MHz transmitters.
 ---
 
 ![Setup-Banner](https://github.com/ExpressLRS/ExpressLRS-Hardware/raw/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/axisflying-thor.md
+++ b/docs/quick-start/transmitters/axisflying-thor.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Axisflying Thor 2.4GHz TX module via WiFi, UART, or EdgeTX passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/betafpv2400.md
+++ b/docs/quick-start/transmitters/betafpv2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for BetaFPV 2.4GHz TX modules via WiFi, UART, or EdgeTX passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/betafpv900.md
+++ b/docs/quick-start/transmitters/betafpv900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for BetaFPV 900MHz TX modules via WiFi, UART, or EdgeTX passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/betafpvlr3pro.md
+++ b/docs/quick-start/transmitters/betafpvlr3pro.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the BetaFPV LR3 Pro internal 2.4GHz transmitter.
 ---
 
 ![Setup-Banner](https://github.com/ExpressLRS/ExpressLRS-Hardware/raw/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/diy2400.md
+++ b/docs/quick-start/transmitters/diy2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for DIY 2.4GHz TX builds using ESP32 with SX1280 RF chips.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/diy900.md
+++ b/docs/quick-start/transmitters/diy900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for DIY 900MHz TX builds using ESP32 with SX127x RF chips.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/emax2400.md
+++ b/docs/quick-start/transmitters/emax2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the EMAX 2.4GHz TX module with pre-installed 3.x firmware.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/emax900.md
+++ b/docs/quick-start/transmitters/emax900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the EMAX 900MHz TX module with pre-installed 3.x firmware.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/es24tx.md
+++ b/docs/quick-start/transmitters/es24tx.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for Happymodel ES24TX 2.4GHz TX module variants (Lite, Slim Pro, Pro).
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/es900tx.md
+++ b/docs/quick-start/transmitters/es900tx.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Happymodel ES900TX 900MHz TX module via WiFi, UART, or EdgeTX passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/flash2400.md
+++ b/docs/quick-start/transmitters/flash2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the NamimnoRC Flash 2.4GHz OLED TX module.
 ---
 
 <figure markdown>

--- a/docs/quick-start/transmitters/frsky-r9modules.md
+++ b/docs/quick-start/transmitters/frsky-r9modules.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for FrSky R9M and R9M Lite Pro STM32-based 900MHz TX modules.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/ghost2400.md
+++ b/docs/quick-start/transmitters/ghost2400.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the ImmersionRC Ghost 2.4GHz STM32-based TX module via STLink.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/hglrc-hermes.md
+++ b/docs/quick-start/transmitters/hglrc-hermes.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the HGLRC Hermes 2.4GHz TX module via WiFi, UART, or EdgeTX passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/iflight-commando.md
+++ b/docs/quick-start/transmitters/iflight-commando.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for iFlight Commando 2.4GHz and 900MHz TX modules.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/jumper-aion.md
+++ b/docs/quick-start/transmitters/jumper-aion.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Jumper Aion Nano 2.4GHz TX module via WiFi, UART, or EdgeTX passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/jumper-internal.md
+++ b/docs/quick-start/transmitters/jumper-internal.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for Jumper TLite V2 internal 2.4GHz and 900MHz transmitters.
 ---
 
 <figure markdown>

--- a/docs/quick-start/transmitters/jumper-t14-t15-internal.md
+++ b/docs/quick-start/transmitters/jumper-t14-t15-internal.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for Jumper T14 and T15 internal 2.4GHz and 900MHz transmitters.
 ---
 
 <figure markdown>

--- a/docs/quick-start/transmitters/jumper-t20-internal.md
+++ b/docs/quick-start/transmitters/jumper-t20-internal.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for Jumper T20 internal 2.4GHz and 900MHz transmitters with Gemini support.
 ---
 
 <figure markdown>

--- a/docs/quick-start/transmitters/rm-bandit.md
+++ b/docs/quick-start/transmitters/rm-bandit.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the RadioMaster Bandit 2.4GHz TX module with pre-installed 3.x firmware.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/rm-internal.md
+++ b/docs/quick-start/transmitters/rm-internal.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for RadioMaster internal 2.4GHz transmitters via WiFi, UART, or EdgeTX passthrough.
 ---
 
 <figure markdown>

--- a/docs/quick-start/transmitters/rm-ranger.md
+++ b/docs/quick-start/transmitters/rm-ranger.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the RadioMaster Ranger 900MHz TX module with pre-installed 3.x firmware.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/siyifm30.md
+++ b/docs/quick-start/transmitters/siyifm30.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the SIYI FM30 STM32-based TX module via STLink.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/vantac-lite.md
+++ b/docs/quick-start/transmitters/vantac-lite.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the Vantac Lite 2.4GHz TX module via WiFi, UART, or EdgeTX passthrough.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/transmitters/voyager900.md
+++ b/docs/quick-start/transmitters/voyager900.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Flashing guide for the NamimnoRC Voyager 900MHz STM32-based TX module.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-hardware/master/img/quick-start.png)

--- a/docs/quick-start/unbricking.md
+++ b/docs/quick-start/unbricking.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Recovery guide for soft-bricked ESP-based ExpressLRS receivers using the factory bootloader.
 ---
 
 ![Setup-Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/quick-start.png)

--- a/docs/software/obsolete-defines.md
+++ b/docs/software/obsolete-defines.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Archive of removed or superseded firmware defines with removal versions and replacements.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/docs/software/open-ocd.md
+++ b/docs/software/open-ocd.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Using OpenOCD on Linux to unlock STLink-based receivers for flashing.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/docs/software/stlink-fix.md
+++ b/docs/software/stlink-fix.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Fixing PlatformIO's outdated STLink tool to support STM32L-based receivers.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/docs/software/testing/crc-testing.md
+++ b/docs/software/testing/crc-testing.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: CRC-14 bit error detection stress test results for the ExpressLRS packet protocol.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/docs/software/testing/rx-scoreboard.md
+++ b/docs/software/testing/rx-scoreboard.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Using the RX Scoreboard debug feature to visualize packet reception per cycle.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/docs/software/testing/unit-testing.md
+++ b/docs/software/testing/unit-testing.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Running ExpressLRS unit tests with PlatformIO and the native platform.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/docs/software/toolchain-install.md
+++ b/docs/software/toolchain-install.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Setting up VSCode, PlatformIO, and Git for ExpressLRS firmware development.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/docs/software/updating/betaflight-passthrough.md
+++ b/docs/software/updating/betaflight-passthrough.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Updating ExpressLRS receivers via Betaflight serial passthrough.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/docs/software/updating/wifi-updating.md
+++ b/docs/software/updating/wifi-updating.md
@@ -1,5 +1,6 @@
 ---
 template: main.html
+description: Updating ExpressLRS devices over WiFi using hotspot, home network, or auto-update methods.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ theme:
 # Plugins
 hooks:
   - overrides/hooks/blog_posts.py
+  - overrides/hooks/llms_txt.py
 
 plugins:
   - blog:

--- a/overrides/hooks/llms_txt.py
+++ b/overrides/hooks/llms_txt.py
@@ -1,0 +1,118 @@
+"""Hook to generate llms.txt at build time from the nav configuration."""
+
+import os
+import yaml
+
+
+def on_post_build(config, **kwargs):
+    """Generate llms.txt in the site output directory."""
+    site_name = config["site_name"]
+    site_url = config["site_url"].rstrip("/") + "/"
+    site_description = config.get("site_description", "")
+    docs_dir = config["docs_dir"]
+    site_dir = config["site_dir"]
+
+    lines = []
+    lines.append(f"# {site_name}")
+    lines.append("")
+    if site_description:
+        lines.append(f"> {site_description}")
+        lines.append("")
+
+    for item in config["nav"]:
+        if isinstance(item, dict):
+            for title, value in item.items():
+                if isinstance(value, str):
+                    # Top-level page (e.g., Home, FAQ)
+                    url = _make_url(site_url, value)
+                    desc = _get_description(docs_dir, value)
+                    lines.append(f"## {title}")
+                    lines.append("")
+                    lines.append(_format_link(title, url, desc))
+                    lines.append("")
+                elif isinstance(value, list):
+                    # Section with children
+                    lines.append(f"## {title}")
+                    lines.append("")
+                    _walk_nav(value, site_url, docs_dir, lines)
+                    lines.append("")
+
+    output = "\n".join(lines).rstrip() + "\n"
+    output_path = os.path.join(site_dir, "llms.txt")
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(output)
+
+
+def _walk_nav(items, site_url, docs_dir, lines):
+    """Recursively walk nav items, emitting link lines for pages."""
+    for item in items:
+        if isinstance(item, str):
+            # Bare path (e.g., blog/index.md used as section index)
+            url = _make_url(site_url, item)
+            title = _get_title(docs_dir, item)
+            if not title:
+                # Derive title from directory name or filename
+                base = item.replace("\\", "/")
+                if base.endswith("/index.md"):
+                    title = base.split("/")[-2].replace("-", " ").title()
+                else:
+                    title = os.path.splitext(os.path.basename(base))[0].replace("-", " ").title()
+            desc = _get_description(docs_dir, item)
+            lines.append(_format_link(title, url, desc))
+        elif isinstance(item, dict):
+            for title, value in item.items():
+                if isinstance(value, str):
+                    url = _make_url(site_url, value)
+                    desc = _get_description(docs_dir, value)
+                    lines.append(_format_link(title, url, desc))
+                elif isinstance(value, list):
+                    # Nested section — recurse without adding a new heading
+                    _walk_nav(value, site_url, docs_dir, lines)
+
+
+def _make_url(site_url, src_path):
+    """Convert a docs source path to an absolute URL."""
+    # index.md -> /
+    # quick-start/getting-started.md -> quick-start/getting-started/
+    path = src_path.replace("\\", "/")
+    if path == "index.md":
+        path = ""
+    elif path.endswith("/index.md"):
+        path = path[: -len("index.md")]
+    elif path.endswith(".md"):
+        path = path[: -len(".md")] + "/"
+    return site_url + path
+
+
+def _get_front_matter(docs_dir, src_path):
+    """Read YAML front matter from a markdown file."""
+    filepath = os.path.join(docs_dir, src_path)
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, IOError):
+        return {}
+    if not content.startswith("---"):
+        return {}
+    try:
+        end = content.index("---", 3)
+        return yaml.safe_load(content[3:end]) or {}
+    except (ValueError, yaml.YAMLError):
+        return {}
+
+
+def _get_description(docs_dir, src_path):
+    """Extract the description field from a page's front matter."""
+    return _get_front_matter(docs_dir, src_path).get("description")
+
+
+def _get_title(docs_dir, src_path):
+    """Extract the title field from a page's front matter."""
+    return _get_front_matter(docs_dir, src_path).get("title")
+
+
+def _format_link(title, url, description=None):
+    """Format a single link line."""
+    if description:
+        return f"- [{title}]({url}): {description}"
+    return f"- [{title}]({url})"


### PR DESCRIPTION
Add MkDocs on_post_build hook that generates /llms.txt from the nav structure, with page descriptions pulled from markdown files. Add description our docs to 72 pages that were missing it across all sections (quick-start, software, hardware, info, blog, etc).