### PR TITLE
bugfix; ArduPilot `SRx_` parameters note

### DIFF
--- a/docs/software/mavlink.md
+++ b/docs/software/mavlink.md
@@ -110,6 +110,9 @@ The minimum versions to use this feature are:
     1. In the Receiver tab, set the Receiver type to `Serial (via UART)` and the `Serial Receiver Provider` to `MAVLINK`.
     1. Save and reboot the flight controller.
 
+!!! note "NOTE: ArduPilot parameters"
+    The `x` in the ArduPilot `SRx_` parameters does **not** need to be the same `x` as the in the `SERIALx` parameters. Often they are the same but that must not always be true. In case of doubt you have to figure this out by trial and error or just set all of them to the same value.
+
 ## Handset Setup
 
 Once your flight controller and ExpressLRS hardware are configured for MAVLink, you should have RC control of your craft from your handset. Setup your RC and switch channels as normal in the EdgeTX model screens.

--- a/docs/software/mavlink.md
+++ b/docs/software/mavlink.md
@@ -82,6 +82,9 @@ The minimum versions to use this feature are:
     1. Configure all `SRx_` parameters to be `1`, except for `SRx_ADSB`, `SRx_PARAMS`, `SRx_RAW_CTRL` that should stay `0` (otherwise yaapu will see a few sensors only and GCS might not be able to connect) 
     1. Save parameters and reboot the flight controller
 
+    !!! note "NOTE: ArduPilot parameters"
+        The `x` in the ArduPilot `SRx_` parameters does **not** need to be the same `x` as the in the `SERIALx` parameters. Often they are the same but that must not always be true. In case of doubt you have to figure this out by trial and error or just set all of them to the same value.
+
 === "PX4"
     For the below steps, when a UART connection is mentioned, it will be written as `SER_TELx`. Replace `x` with the UART number you are using.
 
@@ -109,9 +112,6 @@ The minimum versions to use this feature are:
     1. In the Ports tab, on the UARTx row, make sure `RX Serial` is enabled, set the `Telemetry Output` to `MAVLink`, and the baud rate to `460800`.
     1. In the Receiver tab, set the Receiver type to `Serial (via UART)` and the `Serial Receiver Provider` to `MAVLINK`.
     1. Save and reboot the flight controller.
-
-!!! note "NOTE: ArduPilot parameters"
-    The `x` in the ArduPilot `SRx_` parameters does **not** need to be the same `x` as the in the `SERIALx` parameters. Often they are the same but that must not always be true. In case of doubt you have to figure this out by trial and error or just set all of them to the same value.
 
 ## Handset Setup
 


### PR DESCRIPTION
follow-up to https://github.com/ExpressLRS/Docs/pull/512

As I came across some FC that had 6 SERIAL but only 4 SR it became kind of obvious that these number don't have to match.