### PR TITLE
Fix GH edit URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ site_description: >-
 # Repository
 repo_name: ExpressLRS/ExpressLRS
 repo_url: https://github.com/ExpressLRS/ExpressLRS/releases/
-edit_uri: "https://github.com/ExpressLRS/Docs/tree/master/docs/"
+edit_uri: "https://github.com/ExpressLRS/Docs/edit/master/docs/"
 
 # Copyright
 copyright: Copyright &copy;  2018–2025 ExpressLRS LLC


### PR DESCRIPTION
Currently, the "View source of this page" and "Edit this page" link to the same URL: the `tree` URL. This of course doesn't let users edit the page.

This change *might* fix this, however, `docker compose build` is failing on my Gentoo system (it apparently lacks the `BPF_CGROUP_DEVICE` kernel setting apparently) and `mkdocs` is has been removed from the Gentoo package tree last month.

So I'm hoping this repo comes with PR previews or else hopefully someone else can check if it is fixed with this simple change :slightly_smiling_face: 