### PR TITLE
Add LQ/RSSI to channel output list

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -215,7 +215,7 @@ RDP
 retransmission
 RFMD
 RGB
-RQLY
+RQly
 RSNR
 RSS
 RSSI

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,9 +65,9 @@ hide:
 ??? faq "Is my binding phrase a secret?"
     No, just like what channel your VTX is on is not a secret. If everyone kept their VTX channel a secret, the chances of you blasting someone out of the sky accidentally is high. The binding phrase is *not* used for security, it is used to prevent collisions. Specifically, the binding phrase is hashed and used to seed the random number generator that determines the frequency hopping pattern. Thus, each binding phrase results in a unique hopping pattern, minimizing the likelihood of collisions with other users.  To provide the best chance of not interfering with other pilots and them not interfering with you, be sure you're not using the same dumb bind phrase as someone else. Express your style with a hilarious or saucy bind phrase.
 
-## <span class="custom-heading" data-id="10">What does RQLY, TQLY, RSSI x2, SNR x2 mean?</span>
+## <span class="custom-heading" data-id="10">What does RQly, TQLY, RSSI x2, SNR x2 mean?</span>
 
-??? faq "What do RQLY, TQLY, RSSI x2, SNR x2 mean?"
+??? faq "What do RQly, TQLY, RSSI x2, SNR x2 mean?"
 
     | Datapoint| Description   |   Range | Info |
     |------|-----------------------------------------|---|---|

--- a/docs/software/switch-config.md
+++ b/docs/software/switch-config.md
@@ -28,8 +28,8 @@ This table summarizes the switch configuration modes, available channel switch p
 | 12  | Aux 8 | *16-pos*<sup>RR</sup> | *64-pos*<sup>RR</sup> | - | CRSF Ext<br/>Limits<sup>H</sup> | CRSF Ext<br/>Limits<sup>H</sup> |
 | 13  | Aux 9 | - | - | - | CRSF Ext<br/>Limits<sup>H</sup> | - |
 | 14  | Aux 10 | **2-pos<br/>Arm*** | **2-pos<br/>Arm*** | **2-pos<br/>Arm*** | CRSF Ext<br/>Limits<sup>H</sup> | **2-pos<br/>Arm*** |
-| 15  | Aux 11 | - | - | - | CRSF Ext<br/>Limits<sup>H</sup> | - |
-| 16  | Aux 12 | - | - | - | CRSF Ext<br/>Limits<sup>H</sup> | - |
+| 15  | Aux 11 | LQ% | LQ% | LQ% | CRSF Ext<br/>Limits<sup>H</sup> | LQ% |
+| 16  | Aux 12 | RSSI% | RSSI% | RSSI% | CRSF Ext<br/>Limits<sup>H</sup> | RSSI% |
 |  | Packet <br/>Rates | 50 thru <br/>F1000 | 50 thru <br/>F1000 | Full Res <br/>Only | Full Res <br/>Only | Full Res <br/>Only |
 
 <small>* v4.0 changes, with the introduction of the new arming methods</small>
@@ -44,6 +44,8 @@ This table summarizes the switch configuration modes, available channel switch p
 | **16-pos** | 4-bit which is good for flight modes, flaps, gear, etc. |
 | **6-pos** | 3-bit which is good for flight modes, flaps, gear, etc. |
 | **2-pos** | 1-bit for Arm, ~1000us is the **disarmed** state and ~2000us is the **armed** state (see the explanations below of why the armed state is very important for safety and performance) |
+| **LQ%** | Link Quality % (RQly) expressed as a value 988us to 2012us |
+| **RSSI%** | RSSI dBm % (1RSS/2RSS) expressed as a value 988us to 2012us |
 
 
 !!! warning "WARNING" 


### PR DESCRIPTION
The "Switch Configs" page is never complete! Adds LQ/RSSI to the list since they aren't "-" they are populated. Also updates spellcheck to use the correct RQly telemetry item name instead of RQLY.

<img width="782" height="295" alt="image" src="https://github.com/user-attachments/assets/1d5ff047-fc07-404c-8c12-a74d654685de" />
