### PR TITLE
Ardupilot v4.7.0 parameter rename correction

### DIFF
--- a/docs/software/mavlink.md
+++ b/docs/software/mavlink.md
@@ -76,14 +76,14 @@ The minimum versions to use this feature are:
 ## Flight Controller Setup
 
 === "ArduPilot >= v4.7.0"
-    For the below steps, when a UART connection is mentioned, it will be written as `SERIALx`. Replace `x` with the UART number you are using. For step 2, it would probably be MAV1. Check [this](https://ardupilot.org/copter/docs/common-mavlink-configuration.html#mavlink-advanced-configuration) eplaination from the Ardupilot Wiki
+    For the below steps, when a UART connection is mentioned, it will be written as `SERIALx`. Replace `x` with the UART number you are using. For step 2, it would probably be `MAV2`. Check [this](https://ardupilot.org/copter/docs/common-mavlink-configuration.html#mavlink-advanced-configuration) eplaination from the Ardupilot Wiki
 
     1. Configure `SERIALx_PROTOCOL=2`, `SERIALx_BAUD=460`, and `RSSI_TYPE=5`
     1. Configure all `MAVx_` parameters to be `1`, except for `MAVx_ADSB`, `MAVx_PARAMS`, `MAVx_RAW_CTRL` that should stay `0` (otherwise yaapu will see a few sensors only and GCS might not be able to connect) 
     1. Save parameters and reboot the flight controller
 
 === "ArduPilot <= 4.6.3"
-    For the below steps, when a UART connection is mentioned, it will be written as `SERIALx`. Replace `x` with the UART number you are using. For step 2, it would probably be `SR1`. Check [this](https://ardupilot.org/copter/docs/common-mavlink-configuration.html#mavlink-advanced-configuration) eplaination from the Ardupilot Wiki. Note: Since v4.7.0 Ardupilot renamed `SRx` to `MAVx` so please read this link as SRx if you need to keep on your version.
+    For the below steps, when a UART connection is mentioned, it will be written as `SERIALx`. Replace `x` with the UART number you are using. For step 2, it would probably be `SR2`. Check [this](https://ardupilot.org/copter/docs/common-mavlink-configuration.html#mavlink-advanced-configuration) eplaination from the Ardupilot Wiki. Note: Since v4.7.0 Ardupilot renamed `SRx` to `MAVx`+1 so please read this link as `SRx`-1 if you need to keep on your version.
 
     1. Configure `SERIALx_PROTOCOL=2`, `SERIALx_BAUD=460`, and `RSSI_TYPE=5`
     1. Configure all `SRx_` parameters to be `1`, except for `SRx_ADSB`, `SRx_PARAMS`, `SRx_RAW_CTRL` that should stay `0` (otherwise yaapu will see a few sensors only and GCS might not be able to connect) 

--- a/docs/software/mavlink.md
+++ b/docs/software/mavlink.md
@@ -75,8 +75,15 @@ The minimum versions to use this feature are:
 
 ## Flight Controller Setup
 
-=== "ArduPilot"
-    For the below steps, when a UART connection is mentioned, it will be written as `SERIALx`. Replace `x` with the UART number you are using.
+=== "ArduPilot >= v4.7.0"
+    For the below steps, when a UART connection is mentioned, it will be written as `SERIALx`. Replace `x` with the UART number you are using. For step 2, it would probably be MAV1. Check [this](https://ardupilot.org/copter/docs/common-mavlink-configuration.html#mavlink-advanced-configuration) eplaination from the Ardupilot Wiki
+
+    1. Configure `SERIALx_PROTOCOL=2`, `SERIALx_BAUD=460`, and `RSSI_TYPE=5`
+    1. Configure all `MAVx_` parameters to be `1`, except for `MAVx_ADSB`, `MAVx_PARAMS`, `MAVx_RAW_CTRL` that should stay `0` (otherwise yaapu will see a few sensors only and GCS might not be able to connect) 
+    1. Save parameters and reboot the flight controller
+
+=== "ArduPilot <= 4.6.3"
+    For the below steps, when a UART connection is mentioned, it will be written as `SERIALx`. Replace `x` with the UART number you are using. For step 2, it would probably be `SR1`. Check [this](https://ardupilot.org/copter/docs/common-mavlink-configuration.html#mavlink-advanced-configuration) eplaination from the Ardupilot Wiki. Note: Since v4.7.0 Ardupilot renamed `SRx` to `MAVx` so please read this link as SRx if you need to keep on your version.
 
     1. Configure `SERIALx_PROTOCOL=2`, `SERIALx_BAUD=460`, and `RSSI_TYPE=5`
     1. Configure all `SRx_` parameters to be `1`, except for `SRx_ADSB`, `SRx_PARAMS`, `SRx_RAW_CTRL` that should stay `0` (otherwise yaapu will see a few sensors only and GCS might not be able to connect) 


### PR DESCRIPTION
In Ardupilot 4.7.0 the `SRx` parameters will be remaned top `MAVx` (and +1 :roll_eyes: )... to correct this I added a Ardupilot >= 4.7.0 and a Ardupilot <= 4.6.3 section. I think this last section can be removed in the future.
See this PR https://github.com/ArduPilot/ardupilot_wiki/pull/7870

Also the 
_"For the below steps, when a UART connection is mentioned, it will be written as SERIALx. Replace x with the UART number you are using."_ 
description got me completely [on the wrong foot](https://discuss.ardupilot.org/t/missing-sensors-on-elrs-mavlink-connection/144610)... If you assume this also is the case for the `SRx` parameters (or the new `MAVx`) your incorrect. Most people will have only 2 MAVLink ports so in that case `SR1_*` (or the new `MAV2_*`) will be the parameters to change. But if you have like your elrs receiver on uart5 and a camera on 3 the previous assumption is also incorrect. That is why I added the links to the Ardupilot wiki.

Let me know what you think!