### PR TITLE
lua-howto: document the Administered bind storage mode

### DIFF
--- a/docs/quick-start/transmitters/lua-howto.md
+++ b/docs/quick-start/transmitters/lua-howto.md
@@ -503,6 +503,10 @@ For more information, see [PWM Receivers](../../hardware/pwm-receivers.md) page.
 This option is available on ExpressLRS 3.4.0 and newer. See the details [here](https://github.com/ExpressLRS/ExpressLRS/pull/2542).
 
 * `Returnable` - Introduced in ExpressLRS 3.5.0. It is used to allow models to be safely loaned from a fleet if unbound OTA. A Binding Phrase must be set for this to work properly. see [PR 2744](https://github.com/ExpressLRS/ExpressLRS/pull/2744) for details.
+* `Administered` - Introduced in ExpressLRS 3.5.4. The receiver will not enter Bind Mode by any method. The `Enter Bind Mode` command, the bind button action, and the three power-cycle method all have no effect. Binding information can only be changed from the receiver WebUI. This is intended for a fleet where the binding must not be changed at the field.
+
+!!! warning "Warning"
+	A receiver set to `Administered` will not enter Bind Mode even when it is not bound to a transmitter. The WebUI is the only way to change its binding. Make sure you can reach the WebUI, either through auto WiFi mode or a configured Home WiFi network, before you select `Administered`. If you cannot reach the WebUI you must re-flash the receiver over UART to recover it.
 
 ### Enter Bind Mode command
 


### PR DESCRIPTION
The Bind Storage section lists Persistent, Volatile and Returnable, but not Administered. It is the fourth entry in the Lua selection (`RXParameters.cpp`, `"Persistent;Volatile;Returnable;Administered"`) and in the WebUI binding panel, and it has shipped since 3.5.4.

### What it does

Enforcement is in one place, `EnterBindingMode()` in `rx_main.cpp`:

```cpp
// never enter binding mode if binding is supposed to only be administered through the web UI
if (config.GetBindStorage() == BINDSTORAGE_ADMINISTERED) {
    return;
}
```

Every route into bind mode goes through that function, so all of these are blocked:

| Route | Call site |
|---|---|
| Three power-cycle | `GetPowerOnCounter() >= 3` |
| Automatic bind when unbound | `!OtaUidIsBound(UID)` |
| `Enter Bind Mode` command | `RXEndpoint.cpp` via `EnterBindingModeSafely()` |
| Bind button action | `registerButtonFunction(ACTION_BIND, ...)` |

The WebUI path is not gated. `devWIFI.cpp` only tests bind storage for Volatile and Returnable, so the WebUI remains the only way to change the binding.

### The warning

An unbound receiver set to Administered will not bind over the air either, because the automatic bind path also goes through `EnterBindingMode()`. Recovery is the WebUI, or a UART re-flash if the WebUI cannot be reached. The added warning says so and suggests setting a Home WiFi network first.

### Version

`git tag --contains` on both the original `BINDSTORAGE_PERMANENT` commit and the later rename to `BINDSTORAGE_ADMINISTERED` returns 3.5.4 as the first release containing them.