### PR TITLE
serial-protocols: document GPS, and list the missing protocols

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -174,6 +174,7 @@ Multicopter
 Multicopters
 MultiGP
 NDA
+NMEA
 NPN
 NRST
 Namimno

--- a/docs/quick-start/transmitters/lua-howto.md
+++ b/docs/quick-start/transmitters/lua-howto.md
@@ -419,6 +419,7 @@ The `Protocol` setting controls the output of the connected receiver. The follow
 * `DisplayPort` - For controlling (primarily) DJI Air units to take them out of Low Power mode. New in ExpressLRS 4.0.
 * `HoTT Telemetry` - Allows to use Graupner HoTT enabled telemetry sensors (Graupner and 3rd party)
 * `MAVLINK` - Introduced on ExpressLRS 3.5.0, it allows the receiver to output native MAVLink into a flight controller. See the [MAVLink](../../software/mavlink.md) page for more details.
+* `GPS` - Introduced on ExpressLRS 4.0, it lets you connect a serial GPS directly to the receiver. The receiver reads the NMEA output and sends the position to the handset as telemetry, with no flight controller needed. The port runs at 115200 baud. See the [GPS Notes](../../software/serial-protocols.md#gps-notes) for wiring and setup.
 
 For more information, see [Receiver Serial Protocols](../../software/serial-protocols.md)
 
@@ -426,7 +427,7 @@ For more information, see [Receiver Serial Protocols](../../software/serial-prot
 
 The `Protocol 2` setting is only available for ESP32-based receivers. This include the True Diversity ones like the RP4TD, Super D, Super P and EP Dual. These receivers have a second UART that can be used for the same purpose as the main UART. Note that not all of the ESP32-based receivers have the extra UART pads or pins exposed for easy use.
 
-It has the same options as the setting above with these additional ones:
+It has the same options as the setting above, except for `MAVLINK`, which is only available on the main UART. It also has these additional ones:
 
 * `Tramp` - If you want to control a VTX using Tramp protocol directly through the ExpressLRS Lua Script's VTX Admin.
 * `SmartAudio` - If you want to control a VTX using SmartAudio protocol directly through the ExpressLRS Lua Script's VTX Admin.

--- a/docs/software/serial-protocols.md
+++ b/docs/software/serial-protocols.md
@@ -14,8 +14,13 @@ ExpressLRS receivers can communicate using a variety of serial protocols:
 - SUMD
 - DJI RS2 Pro (Modified SBUS with pre-configured limits)
 - HoTT Telemetry
+- MAVLink
+- DisplayPort
+- GPS
 - Tramp
 - SmartAudio
+
+Not every protocol is available on both serial interfaces. `Tramp` and `SmartAudio` are only available on Serial2. `MAVLink` is only available on Serial 1.
 
 ## Receiver Protocol Selection
 
@@ -269,3 +274,40 @@ Example adapter cable setup for ESP8285 PWM receivers like the Happymodel EPW6:
 <figure markdown>
 ![SuperP 2](../assets/images/HoTT-TLM-P6.png)
 </figure>
+
+## GPS Notes
+
+Available since ExpressLRS 4.0. A serial GPS can be connected directly to a receiver. The receiver reads the NMEA output of the GPS and sends the position to the handset as CRSF telemetry. The flight controller is not involved, so this also works on a model that has no GPS of its own, and on a model that has no flight controller at all.
+
+Select `GPS` as the protocol on Serial 1 or on Serial2. Serial2 is only available on ESP32 receivers.
+
+### Wiring
+
+Only one data wire is needed. Connect the TX pin of the GPS to the Serial RX pin of the receiver. The receiver never sends anything to the GPS, so the Serial TX pin of the receiver can be left unconnected.
+
+Check the voltage and current rating of the GPS module before you connect it to a supply.
+
+### Baud Rate
+
+The receiver opens the port at 115200 baud, 8N1. The receiver does not detect the baud rate, and the rate cannot be changed.
+
+!!! warning "Warning"
+	Most GPS modules leave the factory set to 9600 baud. Set the module to 115200 baud and save the setting to the module before you connect it to the receiver. A module left at 9600 baud will produce no telemetry.
+
+### Supported Sentences
+
+The receiver reads three NMEA sentences. The talker ID is not checked, so `$GP`, `$GN`, and other prefixes are all accepted.
+
+| Sentence | Values used |
+|---|---|
+| `GGA` | Latitude, longitude, satellites in use, altitude |
+| `VTG` | Heading, ground speed |
+| `RMC` | Date and time |
+
+A `GGA` sentence sends the position telemetry frame. A `VTG` sentence does not send a frame of its own, because its values are carried in the next `GGA` frame. An `RMC` sentence sends the GPS time frame, which gives the date and time to the handset.
+
+A sentence with a bad NMEA checksum is discarded. Any other sentence type is ignored.
+
+### Telemetry Bandwidth
+
+Each `GGA` sentence produces one telemetry frame, so a GPS set to 10Hz uses much more of the telemetry budget than the same GPS set to 1Hz. If the link carries other telemetry as well, lower the output rate of the GPS or select a faster `Telem Ratio`. See [Telemetry Bandwidth](../info/telem-bandwidth.md) for more information.


### PR DESCRIPTION
The protocol list on this page names seven protocols. The receiver offers ten (`RXParameters.cpp`). `MAVLink`, `DisplayPort` and `GPS` were all absent, and there was no GPS section at all even though the protocol has shipped since 4.0.

### GPS Notes

A new section covering the parts a user has to get right, all taken from `SerialGPS.cpp` and `rx_main.cpp`:

| Documented | Source |
|---|---|
| Wiring is one way, GPS TX to receiver Serial RX only | `SerialGPS::sendQueuedData()` has an empty body, the receiver never transmits |
| 115200 baud, 8N1, no baud detection | `serialBaud = 115200` for Serial 1 and `Serial1.begin(115200, SERIAL_8N1, ...)` for Serial2; `serialConfig` defaults to `SERIAL_8N1` and is only changed for SBUS and HoTT |
| Only `GGA`, `VTG` and `RMC` are read | `processSentence()` |
| Talker ID is not checked | the match is on `sentence[3..5]`, so `$GP`, `$GN` and others all work |
| `GGA` sends the position frame, `VTG` is folded into the next `GGA` frame, `RMC` sends the time frame | `sendTelemetryFrame()` on GGA, the VTG call is commented out with "VTG usually comes before GGA, only generate one telemetry frame with both combined", `sendGpsTimeTelemetryFrame()` on RMC |
| A bad NMEA checksum discards the sentence | `isValidChecksum()` |
| Serial2 is ESP32 only | `#if defined(PLATFORM_ESP32)` guard around `setupSerial1()` |

The baud rate is the one that matters in practice. It is hardcoded and there is no detection, while most GPS modules ship set to 9600 baud, so a stock module produces no telemetry at all. That has a warning.

### Two other corrections

- The intro list was missing `MAVLink` and `DisplayPort` as well as `GPS`. Added, with a note that `Tramp` and `SmartAudio` are Serial2 only and `MAVLink` is Serial 1 only.
- The Lua page said `Protocol 2` "has the same options as the setting above". Serial2 has no `MAVLink` option, so that is now stated.

`GPS` is also added to the Lua `Protocol` list, which omitted it.

### Not included

I did not document EdgeTX sensor names or a required EdgeTX version for the GPS time frame. Those cannot be verified from the firmware, so they are better added by someone who can confirm them on a handset.

`NMEA` is added to `.wordlist.txt` for the spellcheck. `wordlist.dic` is left alone since it is generated.