### PR TITLE
webui: add a device hostname and access point table

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -50,6 +50,7 @@ CubeProgrammer
 Cura
 DBR
 DFU
+DHCP
 DIY
 DJI
 DMA
@@ -157,6 +158,7 @@ MAVLink
 MCU
 MCUs
 MDL
+MDNS
 MFD
 MHz
 MOSFET
@@ -312,6 +314,7 @@ VIN
 VM
 VMain
 VRX
+VRx
 VSCode
 VSCode's
 VTX
@@ -388,6 +391,8 @@ fontawesome
 fullres
 FullRes
 github
+hostname
+hostnames
 hotspot
 html
 http

--- a/docs/quick-start/webui.md
+++ b/docs/quick-start/webui.md
@@ -218,6 +218,23 @@ description: The ExpressLRS Web UI is an essential part of the ExpressLRS ecosys
                     3. Take note of the IP Address given by your router.
                     4. Use this IP address in your Browser as the URL.
 
+### Device Hostnames and Access Points
+
+Each ExpressLRS device that has a Web UI uses its own hostname and its own Access Point name. Use this table to find the correct name for the device you want to configure.
+
+| Device | Hostname | Access Point |
+|---|---|---|
+| Transmitter module | `elrs_tx.local` | `ExpressLRS TX` |
+| Receiver | `elrs_rx.local` | `ExpressLRS RX` |
+| TX Backpack | `elrs_txbp.local` | Changes with the selected service |
+| VRx Backpack | `elrs_vrx.local` | `ExpressLRS VRx Backpack` |
+| Antenna Tracker Backpack | `elrs_aat.local` | `ExpressLRS AAT Backpack` |
+| Timer Backpack | `elrs_timer.local` | `ExpressLRS Timer Backpack` |
+
+The Access Point password is `expresslrs` on all of these devices. When you are connected to the Access Point, the Web UI is at `http://10.0.0.1/`.
+
+A `.local` hostname only works when the device is connected to your Home WiFi network, and only if MDNS works on your computer and on your network. If the name does not resolve, use the `arp` command or your router DHCP list as described above.
+
 ## The ExpressLRS Web UI Explained
 
 The ExpressLRS Web UI is an essential part of the ExpressLRS ecosystem. In earlier versions of the project, its main use is for updating the ExpressLRS firmware and logging or debugging (on select hardware).


### PR DESCRIPTION
Closes #528.

`elrs_tx.local` and `elrs_rx.local` are documented well. `elrs_txbp.local` and `elrs_vrx.local` appear on the Backpack pages. `elrs_aat.local` and `elrs_timer.local` do not appear anywhere on the site. There is also no single place that lists them, so a user setting up a Backpack has to guess or go searching.

This adds one table at the end of "How to get to the Web UI".

| Device | Hostname | Access Point |
|---|---|---|
| Transmitter module | `elrs_tx.local` | `ExpressLRS TX` |
| Receiver | `elrs_rx.local` | `ExpressLRS RX` |
| TX Backpack | `elrs_txbp.local` | Changes with the selected service |
| VRx Backpack | `elrs_vrx.local` | `ExpressLRS VRx Backpack` |
| Antenna Tracker Backpack | `elrs_aat.local` | `ExpressLRS AAT Backpack` |
| Timer Backpack | `elrs_timer.local` | `ExpressLRS Timer Backpack` |

### Sources

Everything is taken from source rather than from existing docs.

- `elrs_tx` / `elrs_rx` and the `ExpressLRS TX` / `ExpressLRS RX` access point names are in `src/lib/OPTIONS/options.cpp` in this firmware repo, along with `wifi_ap_password = "expresslrs"` and `wifi_ap_address = "10.0.0.1"`.
- `elrs_aat`, `elrs_vrx`, `elrs_txbp` and `elrs_timer` and their access point names are in `lib/WIFI/devWIFI.cpp` in the Backpack repository, selected by `AAT_BACKPACK`, `TARGET_VRX_BACKPACK`, `TARGET_TX_BACKPACK` and `TARGET_TIMER_BACKPACK`.
- The TX Backpack is the one exception. Its SSID is `static char wifi_ap_ssid[33]` and is filled in at runtime from the selected `wifiService`, so the table says it changes rather than naming a fixed string.
- The Backpack uses the same `expresslrs` password and the same `10.0.0.1` address (`static IPAddress apIP(10, 0, 0, 1)`).

### Word list

Adds `DHCP`, `MDNS`, `VRx`, `hostname` and `hostnames`.

These terms are already used across the site, but every existing occurrence sits inside an admonition body. The spellcheck's markdown filter loads only `markdown.extensions.extra`, so those indented blocks are parsed as code blocks and skipped. The new table is top level prose, so the words are checked for the first time.

`VRx` is kept in that exact mixed case because it is the literal SSID string the user sees when picking a network.