### PR TITLE
webui: document Voltage Calibration, WiFi State and the password reveal

### DIFF
--- a/docs/quick-start/webui.md
+++ b/docs/quick-start/webui.md
@@ -234,6 +234,13 @@ ExpressLRS 4.0 improves upon this with a new layout allowing for more sections o
     ### Information Tab
     This Tab will show the basic information about the device, including Hardware name, Firmware version, GitHub commit hash, Radio Chip, Regulatory Domain, Binding UID and any options that's been changed from the default or flashed settings.
 
+    The `WiFi State` row shows how the device is connected. In Home WiFi mode it shows `Client` and the network name. In Access Point mode it shows `AP mode`. Where the device can measure it, the row also shows the WiFi signal strength in dBm followed by a short description of the quality.
+
+    A weak WiFi signal makes a firmware upload slow, and can make it fail part way through. If the value is worse than -80dBm, move the device closer to the router, or use the Access Point instead of Home WiFi, before you use the Update Tab.
+
+    !!! note "Note"
+        The signal strength means different things in the two modes. In Home WiFi mode it is how well the device hears your router. In Access Point mode it is how well the device hears the one connected client, and it is not shown at all on ESP8285 devices.
+
     <figure markdown>
     ![Information Tab](../assets/images/webui/information.png)
     </figure>
@@ -316,6 +323,8 @@ ExpressLRS 4.0 improves upon this with a new layout allowing for more sections o
 
     This tab lets you change the device' WiFi network connectivity and how it will behave when it is in WiFi mode.
 
+    The password field has an eye button at its right edge. Use it to show the stored Home WiFi password in plain text, which is useful to check a password that does not connect. The password becomes readable by anyone who can see the screen, so hide it again before you show the page to someone else or share a screenshot.
+
     <figure markdown>
     ![WiFi Tab](../assets/images/webui/wifi.png)
     </figure>
@@ -338,6 +347,27 @@ ExpressLRS 4.0 improves upon this with a new layout allowing for more sections o
     <figure markdown>
     ![HW Layout Tab](../assets/images/webui/hardware.png)
     </figure>
+
+    ### Voltage Calibration
+
+    Introduced in ExpressLRS 4.1. This tab appears on receivers that have at least one voltage source defined in the Hardware Layout. It runs a wizard that measures your receiver against a known voltage and works out the correct scale and offset, so the battery voltage reported over telemetry matches reality.
+
+    You need an adjustable power supply, or a battery and a multimeter, to give the receiver a voltage you already know.
+
+    Select the source to calibrate, then work through the four steps:
+
+    1. **High Voltage**. Apply a voltage near the top of the range you want to measure, type the actual value in millivolts, and capture it.
+    2. **Low Voltage**. Apply a lower known voltage, type the actual value in millivolts, and capture it.
+    3. **No Voltage**. Disconnect the source and capture the idle reading. Skip this step if the source is always connected.
+    4. **Review**. The wizard shows the calculated offset and scale, and how far the fit is from your two known points. Reconnect the source, check the live reading, then save.
+
+    The receiver reboots when the calibration is saved. On ESP32 receivers the wizard also tries each available input attenuation and keeps the one that gives the best result without the reading going off scale.
+
+    !!! warning "Warning"
+        Do not apply a voltage above what the receiver is designed for. The voltage divider on the board sets that limit, and the wizard cannot protect the hardware. Check the specification for your receiver first.
+
+    !!! note "Note"
+        The calibration is stored in the Hardware Layout, so it is kept when the settings are exported and restored. Flashing a device and choosing not to keep the existing configuration will discard it.
 
     ### Continuous Wave
 


### PR DESCRIPTION
Three parts of the 4.1 Web UI are missing from this page.

### Voltage Calibration

A whole tab that is not mentioned anywhere on the site. Added between Hardware Layout and Continuous Wave to match the navigation menu order in `app.js`.

Scope and gating come from `app.js`: the menu entry sits inside `<!-- FEATURE:NOT IS_TX -->` and is only emitted when `elrsState.settings?.voltage_source_count > 0`, so it is receivers only and only when the Hardware Layout defines a voltage source.

The four steps match `voltage-calibration-panel.js` exactly:

| Step | Panel |
|---|---|
| 1. High Voltage | `'1. High Voltage'`, "Set a known voltage near ... and capture it", input labelled `Known voltage (mV)` |
| 2. Low Voltage | `'2. Low Voltage'`, same input |
| 3. No Voltage | `'3. No Voltage'`, "Disconnect the source and capture the idle reading, or skip if it is always present", with Capture and Skip |
| 4. Review | `'4. Review'`, shows offset, scale, no-reading and the low/high fit error, then "Reconnect or adjust the PSU and confirm the live reading before saving" |

Saving writes `<source>_offset`, `<source>_scale`, `<source>_atten` and `<source>_noreading` into `hardware.json` with `customised: true` via `saveJSONWithReboot`, which is why the section says the receiver reboots and why the calibration travels with the Hardware Layout on export.

The attenuation sweep is ESP32 only. `CALIBRATION_ATTENUATIONS` is `[4,5,6,7]` on ESP32 and `[-1]` under `FEATURE:IS_8285`, so the text limits that claim to ESP32.

The warning about input voltage is included because the wizard has no way to protect the hardware; the limit is set by the divider on the board.

### Information Tab

The `WiFi State` row was not described. It is `formatWifiRssi()` from `state.js`, rendered by `info-panel.js`. Note this is on the Information tab, not the WiFi tab.

It shows `Client [ssid]` or `AP mode`, plus the strength in dBm when `wifi_dbm` is non-zero. The note records that the value means different things per mode, because `wifi_GetClientRssi()` returns `WiFi.RSSI()` in STA mode but the RSSI of the single connected client in AP mode, and returns nothing on ESP8285. A weak signal causing a failed firmware upload is a common support question, so that is called out.

I deliberately did not reproduce the quality strings verbatim. They include a joke tier and an easter egg at exactly -69dBm, so the page describes them generically rather than treating them as a stable interface.

### WiFi Tab

The control that reveals the stored password was not documented. `wifi-panel.js` toggles the field between `password` and `text` with an eye button. The text notes the obvious consequence before sharing a screenshot.