### PR TITLE
lua-howto: document the Antenna Group receiver setting

### DIFF
--- a/docs/quick-start/transmitters/lua-howto.md
+++ b/docs/quick-start/transmitters/lua-howto.md
@@ -448,6 +448,20 @@ The `Antenna Mode` setting is only available for Receivers with Antenna Diversit
 * `Diversity` - Both Antennas will be active. Receiver will switch to the antenna with better RSSI.
 * `Ant1/Ant2` - Only one antenna will be enabled (for both RC command reception and Telemetry sending).
 
+### Antenna Group
+
+Introduced in ExpressLRS 4.1. The `Ant. Group` setting selects which set of antenna ports the receiver uses. These options are available:
+
+* `External` - Use the external antenna connectors.
+* `Builtin` - Use the antennas built into the receiver board.
+
+The setting drives a pin that controls an antenna switch on the receiver, and the pin is refreshed continuously, so a change takes effect at once and no reboot is needed. The choice is stored with the model and is kept across power cycles.
+
+`Ant. Group` is separate from `Antenna Mode`. `Ant. Group` selects which ports are connected to the radio, and `Antenna Mode` selects how the receiver uses the ports it has.
+
+!!! note "Note"
+    This setting only appears on receivers whose hardware defines an antenna group pin. Most receivers do not have one, so the setting is not shown.
+
 ### Receiver Mode
 
 The `Receiver Mode` setting is only available for True Diversity receivers. These options are available:


### PR DESCRIPTION
`Ant. Group` was added in 4.1 and has no documentation on the site. It sits directly next to `Antenna Mode` in the receiver settings and the two are easy to confuse, so the new section is placed after `Antenna Mode` and states the difference explicitly.

### Verified behavior

| Documented | Source |
|---|---|
| Options are exactly `External` and `Builtin` | `luaAntennaGroup` in `RXParameters.cpp`, option string `"External;Builtin"` |
| Only appears on receivers with the pin defined | registration is wrapped in `if (GPIO_PIN_ANT_GROUP != UNDEF_PIN)` |
| Takes effect immediately, no reboot | `digitalWrite(GPIO_PIN_ANT_GROUP, config.GetAntennaGroup())` is inside `updateDiversity()` in `rx_main.cpp`, which runs continuously rather than only at boot |
| Stored with the model, survives a power cycle | `RxConfig::SetAntennaGroup` sets `EVENT_CONFIG_MODEL_CHANGED` |
| New in 4.1 | introduced by the antenna group Lua option and pin definition commits; `git tag --contains` returns only 4.1.0 and 4.1.0-RC1 |

### Naming note for reviewers

There is an inconsistency in the firmware that I did not carry into the docs. The Lua parameter offers `External;Builtin`, but the Hardware Layout schema describes the same pin as selecting "internal/external antenna port(s)". The page uses the Lua labels, since those are what the user actually sees in the script and the Web UI. Worth aligning upstream at some point.

I did not state a default. The field is a 1 bit config value and is not explicitly initialised in `SetDefaults`, so while it is almost certainly `External`, that follows from struct zeroing rather than from anything explicit, and it did not seem worth asserting.