### PR TITLE
pre-1stflight: link the ExpressLRS Telemetry Widget

### DIFF
--- a/docs/quick-start/pre-1stflight.md
+++ b/docs/quick-start/pre-1stflight.md
@@ -168,6 +168,19 @@ If you use 200Hz and 1:2 Tlm ratio the stars will not even blink because the upd
 ![Fast update rate](https://github.com/ExpressLRS/ExpressLRS-Hardware/raw/master/img/wiki-from-discord/fast.gif)
 </figure>
 
+### ExpressLRS Telemetry Widget
+
+Once your sensors are discovered, you can show them on the handset home screen with the [ExpressLRS Telemetry Widget](https://github.com/ExpressLRS/ElrsTelemWidget). This is an official ExpressLRS project. It shows the ExpressLRS link statistics next to the common Betaflight and iNav values, so you can check the state of the link without opening the telemetry page.
+
+To install it, copy the `src/WIDGETS/ELRST` folder from that repository into the `WIDGETS/` folder on your handset SD card. The card must then hold the file `WIDGETS/ELRST/main.lua`. Discover your sensors first, then press the telemetry key, go to the widget setup page, and add the `ELRS Telem` widget to a free space. If you add the widget before the sensors are discovered, restart the handset after you discover them.
+
+A correct sensor discovery gives 17 sensors with Betaflight, and 23 with iNav when a GPS is fitted. Use this as a check that your telemetry is set up properly.
+
+The same repository holds function scripts that let you bind from a switch. Attach `ELRSb.lua`, `ELRSu.lua`, or `ELRSt.lua` to a Special Function.
+
+!!! note "Note"
+    The widget repository gives its tested configuration as a RadioMaster TX16S with EdgeTX 2.5. There is no current compatibility list for later handsets or later EdgeTX versions, so report any problem you find on the widget repository.
+
 ## MSP
 
 To configure Betaflight from your transmitter it's possible to use the Betaflight lua scripts. If you are having trouble, make sure you are running the latest [Betaflight nightly lua](https://github.com/betaflight/betaflight-tx-lua-scripts-nightlies/releases). 


### PR DESCRIPTION
Closes #419.

[ElrsTelemWidget](https://github.com/ExpressLRS/ElrsTelemWidget) is an official ExpressLRS project, but the site never mentions it. Grepping the whole docs tree for `telemwidget`, `telemetry widget` or `ElrsTelem` returns zero hits.

Issue #419 asks for it to be surfaced during first time setup, so this adds a subsection to the Telemetry section of the first flight page, immediately after sensor discovery. That is the moment the user has just built their sensor list and is looking at the telemetry screen, so it is the point where the widget is most useful.

### Content

Everything is taken from the widget README rather than invented:

- Install path `src/WIDGETS/ELRST` into `WIDGETS/` so the card holds `WIDGETS/ELRST/main.lua`
- Discover sensors before adding the widget, and restart the handset if that order is missed
- Expected sensor counts, 17 with Betaflight and 23 with iNav plus GPS, which doubles as a check that telemetry is set up correctly
- The `ELRSb.lua`, `ELRSu.lua` and `ELRSt.lua` function scripts for binding from a switch

### Compatibility statement

The README still says "Tested on Radiomaster TX16S with EdgeTX 2.5 only" and there is no newer statement anywhere in the repository. Rather than paper over that, the note repeats it as written and points bug reports at the widget repository. I did not claim it works on current handsets or current EdgeTX, because I have no way to verify that.

A current compatibility matrix would be a good follow up, but it needs someone with the hardware to test rather than a docs change.