### PR TITLE
unbricking: document the full chip erase

### DIFF
--- a/docs/quick-start/unbricking.md
+++ b/docs/quick-start/unbricking.md
@@ -99,6 +99,33 @@ Follow the steps below very closely to recover your "bricked" Receiver.
 <iframe width="640" height="390" src="https://www.youtube.com/embed/jYLwaWBkM_A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </figure>
 
+## Full Chip Erase
+
+If a normal reflash completes but the device still misbehaves, the stored settings are the next thing to suspect. A full chip erase wipes the whole flash before the new firmware is written, so the device starts from a clean state.
+
+Use it when:
+
+- The device boots into a loop, or keeps returning to WiFi mode, after a flash that reported success.
+- You flashed the wrong target onto the device and settings from that target are still present.
+- Binding, model match, or output settings behave in a way that does not match what the Web UI shows.
+
+To do it, tick `Erase before flash` in the `Flashing Options` list of the ExpressLRS Configurator, then flash as normal.
+
+The option only appears for flashing methods that can erase:
+
+| Flashing method | `Erase before flash` |
+|---|---|
+| UART | Available |
+| EdgeTX Passthrough | Available |
+| Betaflight Passthrough | Available on ESP8285 devices only |
+| WiFi | Not available |
+
+!!! warning "Warning"
+    A full chip erase removes everything the device has stored. The binding phrase, the model settings, the output and serial configuration, and any customised Hardware Layout are all lost, and none of them can be recovered afterwards. Export your settings from the Import/Export tab of the Web UI first if the device still starts far enough to reach it.
+
+!!! note "Note"
+    A chip erase cannot brick the device. The factory bootloader described at the top of this page is not part of the erasable flash, so UART recovery is always available afterwards.
+
 ## What about the TX?
 
 Most ESP-based ExpressLRS TX Modules either have the via UART Flashing Procedure or the via ETX Passthrough Flashing method available to them. Use any of these other methods to recover your ESP-based TX Module. 


### PR DESCRIPTION
Closes #335.

A full chip erase is not documented anywhere on the site. The only `esptool` mention is in the toolchain setup page, and there is no "erase" content at all, so a user whose device still misbehaves after a clean reflash has no documented next step.

The Unbricking page is the natural home. It is already the central recovery guide, and it already explains that the factory bootloader cannot be damaged, which is exactly the reassurance needed before telling somebody to wipe their flash.

### Verified against the Configurator and the flashing tooling

| Documented | Source |
|---|---|
| Labelled `Erase before flash`, under `Flashing Options` | `messages.json`, `"EraseBeforeFlash": "Erase before flash"`, rendered in the `FlashingOptions` list |
| Offered for UART | `eraseSupported` in `ConfiguratorView/index.tsx` |
| Offered for EdgeTX Passthrough | same |
| Offered for Betaflight Passthrough only on ESP8285 | same, `flashingMethod === BetaflightPassthrough && device.platform === 'esp8285'` |
| Never offered for WiFi | `eraseSupported` returns false for everything else |
| It really is a full erase | `--erase` in `binary_configurator.py` appends `--erase-all` to the esptool `write_flash` call in `binary_flash.py`, for the ESP8266 UART, ESP8266 Betaflight passthrough, ESP32 UART and ESP32 EdgeTX passthrough paths |

### The warning

This is the part that matters. An erase discards the binding phrase, the model and output configuration, and any customised Hardware Layout, and none of it can be recovered. The text tells the user to export from the Import/Export tab first, while the device still starts far enough to reach the Web UI.

There is also a note that a chip erase cannot brick the device, since the factory bootloader is not in the erasable flash. That is consistent with what the top of the same page already says, and it is the reason this is safe to recommend as a last resort.

### Scope note

I deliberately did not consolidate the Repartitioner boilerplate in this PR. That text is duplicated across roughly 30 device pages and deduplicating it is a large refactor with its own review burden, separate from the missing chip erase content that #335 actually asks for.