### PR TITLE
wiring-up: explain receiver supply at high telemetry power

### DIFF
--- a/docs/quick-start/receivers/wiring-up.md
+++ b/docs/quick-start/receivers/wiring-up.md
@@ -43,6 +43,27 @@ Now that you have some basic info, connect your receiver to any free UART on you
 ![Receiver-to-FC Wiring](../../assets/images/receiver-wiring-to-FC.png)
 </figure>
 
+### Powering the Receiver
+
+A receiver draws far more current while it sends telemetry than while it only listens, and the amount rises with the `Tlm Power` setting. A receiver with a power amplifier, set to a high telemetry power, can ask for more current in short bursts than a small flight controller regulator can supply.
+
+When that happens the supply voltage dips, the receiver resets, and the link drops and recovers. This looks exactly like a radio problem, so it is easy to spend a long time on antennas and packet rates when the cause is the 5v rail.
+
+Two things point to the supply rather than the link:
+
+- The problem follows the `Tlm Power` setting instead of the distance. Lower `Tlm Power` and see whether it stops.
+- The receiver restarts, rather than only losing packets. A restart shows as the LED returning to its startup or waiting pattern.
+
+To avoid it:
+
+- Use a 5v pad that comes from a regulator with enough capacity, not from a rail shared with several other loads.
+- Keep the power wires short, and do not use thinner wire than the receiver came with. A long thin wire drops voltage under a current spike.
+- If your model needs high telemetry power, consider feeding the receiver from its own regulator rather than the flight controller.
+- Raise `Tlm Power` one step at a time and test after each step, instead of setting maximum straight away.
+
+!!! note "MatchTX"
+    With `Tlm Power` set to `MatchTX`, the receiver follows the power the transmitter reports. Dynamic Power raises the transmitter power when the link gets worse, so the receiver draws the most current at exactly the moment the link is already struggling. If a marginal supply is going to fail, this is when it fails.
+
 Check for shorts between pads and clean up flux or any soldering residue if you have soldered the receiver yourself. 
 
 !!! warning "Not so fast!"


### PR DESCRIPTION
Closes #493.

Nothing on the site connects a receiver reset to its telemetry power setting. Grepping the docs tree for `brownout`, `voltage drop` or `power draw` returns zero hits, and the wiring page says only "The VCC or 5 pad should be connected to any 5v (or 4v5) pad".

Meanwhile the AirPort page actively tells the user to "set the RX telemetry power output to maximum", and notes that "Receivers with higher telemetry power output (i.e. 100mW telemetry power) will provide better results", with no mention of what that does to the supply.

### Why this is worth a section

The failure mode points away from its cause. The rail dips under a transmit burst, the receiver resets, and the link drops and recovers. That presents as an antenna, packet rate or range problem, so the obvious next steps are all the wrong ones.

The section gives two signs that separate a supply fault from a link fault:

- The problem tracks the `Tlm Power` setting rather than distance, so lowering `Tlm Power` is a direct test.
- The receiver restarts rather than only losing packets, which is visible as the LED returning to its startup or waiting pattern.

### The MatchTX note

This is the part I think is most useful, and it is verifiable. With `Tlm Power` set to `MatchTX`, `DynamicPower_UpdateRx()` sets receiver power from `linkStats.uplink_TX_Power`, so the receiver follows the transmitter. Dynamic Power raises transmitter power as the link degrades. Peak receiver current therefore arrives exactly when the link is already weak, which is when a marginal supply will give out.

### What is deliberately absent

No current figures, no regulator ratings, no "needs X mA at Y mW" table.

Those numbers vary per receiver and per amplifier and cannot be derived from the firmware or from anything else in the repositories. Issue #493 has an empty body, so there is no source for them there either. Writing plausible looking figures into the manual would be worse than leaving them out, so the section stays qualitative and actionable instead. If someone measures real figures for common receivers, they would slot straight in.