### PR TITLE
Fix description of Software > Trainer page

### DIFF
--- a/docs/software/trainer-input.md
+++ b/docs/software/trainer-input.md
@@ -1,6 +1,6 @@
 ---
 template: main.html
-description: ExpressLRS Bi-directional MAVLink support
+description: Receive channel data from external sources.
 ---
 
 ![Software Banner](https://raw.githubusercontent.com/ExpressLRS/ExpressLRS-Hardware/master/img/software.png)
@@ -33,6 +33,7 @@ Scroll down to "HT Enable" and set this to "On"
 ![HT Enable](../assets/screenshots/ht-enable.png)
 
 ### Direct Channel Output
+
 As mentioned above ExpressLRS can override channels directly being sent to the receiver.
 To achieve this, set the "HT Start Channel" to a value from "Aux1" to "Aux10".
 


### PR DESCRIPTION
Fixes a copy-paste mistake. The current description is the MAVLink page description.

It is not obvious to me whether the description should end with a period or not. This specific one is a sentence, and most other do end with a period, so I'd go with that.

_With that said, I didn't find where / if the description is displayed at all._